### PR TITLE
Added metadata parsing to TDSCatalog object

### DIFF
--- a/siphon/metadata.py
+++ b/siphon/metadata.py
@@ -15,14 +15,14 @@ class _SimpleTypes(object):
         self._valid["dataType"] = self._load_valid_data_types()
 
     def _load_valid_data_types(self):
-        valid = ["Grid",
-                 "Image",
-                 "Point",
-                 "Radial",
-                 "Station",
-                 "Swath",
-                 "Trajectory"]
-        return map(lambda x: x.lower(), valid)
+        valid = ["grid",
+                 "image",
+                 "point",
+                 "radial",
+                 "station",
+                 "swath",
+                 "trajectory"]
+        return valid
 
     def _load_valid_data_format_types(self):
         import mimetypes
@@ -73,9 +73,8 @@ class _SimpleTypes(object):
             attr = attrib
             val = element.attrib[attr]
             if val not in valid:
-                msg = "Value {} not valid for type {}: ".format(val, type_name)
-                msg = msg + " must be {}".format(valid)
-                logging.warning(msg)
+                logging.warning("Value %s not valid for type %s: must be %s",
+                                val, type_name, valid)
         return {attr: val}
 
     def handle_dataFormat(self, element):  # noqa
@@ -128,9 +127,8 @@ class _SimpleTypes(object):
         valid = self._valid[type_name]
         val = element.text
         if val not in valid:
-            msg = "Value {} not valid for type {}: ".format(val, type_name)
-            msg = msg + " must be {}".format(valid)
-            logging.warning(msg)
+            logging.warning("Value %s not valid for type %s: must be %s",
+                            val, type_name, valid)
         return {type_name: val}
 
     def handle_dataType(self, element):  # noqa
@@ -154,9 +152,8 @@ class _SimpleTypes(object):
 
         val = element.text
         if val.lower() not in valid:
-            msg = "Value {} not valid for type {}: ".format(val, type_name)
-            msg = msg + " must be {}".format(valid)
-            logging.warning(msg)
+            logging.warning("Value %s not valid for type %s: must be %s",
+                            val, type_name, valid)
         return {type_name: val}
 
 
@@ -216,9 +213,8 @@ class _ComplexTypes(object):
                     spatial_range[child.tag] = child.text
             else:
                 # child not valid
-                msg = "{} is not valid for type {}: ".format(child_name,
-                                                             type_name)
-                logging.warning(msg)
+                logging.warning("%s is not valid for type %s",
+                                child_name, type_name)
         return spatial_range
 
     def handle_controlledVocabulary(self, element):  # noqa
@@ -236,9 +232,8 @@ class _ComplexTypes(object):
         val = {}
         for attr in opt_attrs:
             if attr not in element.attrib:
-                msg = "{} must have an attribute: {}".format(type_name,
-                                                             attr)
-                logging.warning(msg)
+                logging.warning("%s must have an attribute: %s", type_name,
+                                attr)
             else:
                 val[attr] = element.attrib[attr]
 
@@ -262,9 +257,8 @@ class _ComplexTypes(object):
         val = {}
         for attr in element.attrib:
             if attr not in valid_attrs:
-                msg = "{} is not a valid attribute for {}".format(attr,
-                                                                  type_name)
-                logging.warning(msg)
+                logging.warning("%s is not a valid attribute for %s", attr,
+                                type_name)
             else:
                 val[attr] = element.attrib[attr]
 
@@ -295,9 +289,8 @@ class _ComplexTypes(object):
                 if "email" in child.attrib:
                     value["email"] = child.attrib["email"]
                 else:
-                    msg = "{} must have an attribute: {}".format("contact",
-                                                                 "email")
-                    logging.warning(msg)
+                    logging.warning("'contact' must have an attribute: "
+                                    "'email'")
                     value["email"] = "missing"
             if value:
                 parsed.update(value)
@@ -328,8 +321,7 @@ class _ComplexTypes(object):
                     value[child.tag] = child.text
                 parsed.update(value)
         else:
-            msg = "Not enough elements to make a valid timeCoverage"
-            logging.warning(msg)
+            logging.warning("Not enough elements to make a valid timeCoverage")
 
         return parsed
 
@@ -349,9 +341,8 @@ class _ComplexTypes(object):
         for req_attr in req_attrs:
             if req_attr not in element.attrib:
                 valid = False
-                msg = "{} must have an attribute {}".format(type_name,
-                                                            req_attr)
-                logging.warning(msg)
+                logging.warning("%s must have an attribute %s", type_name,
+                                req_attr)
             variable = {}
         if valid:
             if element.text:
@@ -524,9 +515,7 @@ class TDSCatalogMetadata(object):
         try:
             parser[element_name](element)
         except KeyError:
-            msg = "no parser found for element {}".format(element_name)
-            logging.error(msg)
-            print(msg)
+            logging.error("No parser found for element %s", element_name)
             raise
 
     def _parse_documentation(self, element):
@@ -600,12 +589,10 @@ class TDSCatalogMetadata(object):
         element_type = "contributor"
         role = element.attrib["role"]
         name = element.text
-        self.metadata.setdefault(element_type, {})
-        self.metadata[element_type].setdefault(role, []).append(name)
+        self.metadata.setdefault(element_type, {}).setdefault(role, []).append(name)
 
     def _parse_geospatial_coverage(self, element):
         element_type = "geospatialCoverage"
-        self.metadata.setdefault(element_type, [])
         md = {}
         # <xsd:element name="geospatialCoverage">
         #  <xsd:complexType>
@@ -638,9 +625,8 @@ class TDSCatalogMetadata(object):
                     value = handler(element)
                     md.update({attr: value})
                 else:
-                    msg = "Attr on {} : {} not captured".format(attr,
-                                                                element_type)
-                    logging.warning(msg)
+                    logging.warning("Attr on %s : %s not captured", attr,
+                                    element_type)
 
         for child in element:
             child_name = child.tag
@@ -649,8 +635,7 @@ class TDSCatalogMetadata(object):
                 handler = self._get_handler(handler_name)
                 value = handler(child)
                 md.update(value)
-
-        self.metadata[element_type].append(md)
+        self.metadata.setdefault(element_type, []).append(md)
 
     def _parse_service_name(self, element):
         # can only have one serviceName
@@ -659,32 +644,27 @@ class TDSCatalogMetadata(object):
 
     def _parse_authority(self, element):
         element_type = "authority"
-        self.metadata.setdefault(element_type, [])
-        self.metadata[element_type].append(element.text)
+        self.metadata.setdefault(element_type, []).append(element.text)
 
     def _parse_publisher(self, element):
         element_type = "publisher"
-        self.metadata.setdefault(element_type, [])
         parsed = self._ct.handle_sourceType(element)
-        self.metadata[element_type].append(parsed)
+        self.metadata.setdefault(element_type, []).append(parsed)
 
     def _parse_creator(self, element):
         element_type = "creator"
-        self.metadata.setdefault(element_type, [])
         parsed = self._ct.handle_sourceType(element)
-        self.metadata[element_type].append(parsed)
+        self.metadata.setdefault(element_type, []).append(parsed)
 
     def _parse_keyword(self, element):
         element_type = "keyword"
-        self.metadata.setdefault(element_type, [])
         parsed = self._ct.handle_controlledVocabulary(element)
-        self.metadata[element_type].append(parsed)
+        self.metadata.setdefault(element_type, []).append(parsed)
 
     def _parse_project(self, element):
         element_type = "project"
-        self.metadata.setdefault(element_type, [])
         parsed = self._ct.handle_controlledVocabulary(element)
-        self.metadata[element_type].append(parsed)
+        self.metadata.setdefault(element_type, []).append(parsed)
 
     def _parse_data_format(self, element):
         element_type = "dataFormat"  # noqa
@@ -699,17 +679,14 @@ class TDSCatalogMetadata(object):
     def _parse_date(self, element):
         element_type = "date"
         parsed = self._ct.handle_dateTypeFormatted(element)
-        self.metadata.setdefault(element_type, [])
-        self.metadata[element_type].append(parsed)
+        self.metadata.setdefault(element_type, []).append(parsed)
 
     def _parse_timeCoverage(self, element):  # noqa
         element_type = "timeCoverage"
         parsed = self._ct.handle_timeCoverageType(element)
-        self.metadata.setdefault(element_type, [])
-        self.metadata[element_type].append(parsed)
+        self.metadata.setdefault(element_type, []).append(parsed)
 
     def _parse_variableMap(self, element):  # noqa
         element_type = "variableMap"
         parsed = self._ct.handle_variableMap(element)
-        self.metadata.setdefault(element_type, [])
-        self.metadata[element_type].append(parsed)
+        self.metadata.setdefault(element_type, []).append(parsed)

--- a/siphon/metadata.py
+++ b/siphon/metadata.py
@@ -1,0 +1,715 @@
+from __future__ import print_function
+
+from ._version import get_versions
+import logging
+
+userAgent = 'siphon (%s)' % get_versions()['version']
+
+
+class _SimpleTypes(object):
+
+    def __init__(self):
+        self._valid = {}
+        self._valid["dataFormat"] = self._load_valid_data_format_types()
+        self._valid["upOrDown"] = self._load_valid_up_or_down()
+        self._valid["dataType"] = self._load_valid_data_types()
+
+    def _load_valid_data_types(self):
+        valid = ["Grid",
+                 "Image",
+                 "Point",
+                 "Radial",
+                 "Station",
+                 "Swath",
+                 "Trajectory"]
+        return map(lambda x: x.lower(), valid)
+
+    def _load_valid_data_format_types(self):
+        import mimetypes
+        valid = ["BUFR",
+                 "ESML",
+                 "GEMPAK",
+                 "GINI",
+                 "GRIB-1",
+                 "GRIB-2",
+                 "HDF4",
+                 "HDF5",
+                 "McIDAS-AREA",
+                 "NcML",
+                 "NetCDF",
+                 "NetCDF-4",
+                 "NEXRAD2",
+                 "NIDS",
+                 "image/gif",
+                 "image/jpeg",
+                 "image/tiff",
+                 "text/csv",
+                 "text/html",
+                 "text/plain",
+                 "text/tab-separated-values",
+                 "text/xml",
+                 "video/mpeg",
+                 "video/quicktime",
+                 "video/realtime"]
+
+        valid_mime_types = mimetypes.types_map.values()
+        valid.extend(valid_mime_types)
+        return valid
+
+    def _load_valid_up_or_down(self):
+        valid = ["up", "down"]
+        return valid
+
+    def handle_upOrDown(self, element):  # noqa
+        # name="upOrDown"
+        #   <xsd:restriction base="xsd:token">
+        #    <xsd:enumeration value="up"/>
+        #    <xsd:enumeration value="down"/>
+        #   </xsd:restriction>
+        #
+        type_name = "upOrDown"
+        valid = self._valid[type_name]
+        for attrib in element.attrib:
+            attr = attrib
+            val = element.attrib[attr]
+            if val not in valid:
+                msg = "Value {} not valid for type {}: ".format(val, type_name)
+                msg = msg + " must be {}".format(valid)
+                logging.warning(msg)
+        return {attr: val}
+
+    def handle_dataFormat(self, element):  # noqa
+        # name="dataFormatTypes"
+        #   <xsd:union memberTypes="xsd:token mimeType">
+        #     <xsd:simpleType>
+        #       <xsd:restriction base="xsd:token">
+        #         <xsd:enumeration value="BUFR"/>
+        #         <xsd:enumeration value="ESML"/>
+        #         <xsd:enumeration value="GEMPAK"/>
+        #         <xsd:enumeration value="GINI"/>
+        #         <xsd:enumeration value="GRIB-1"/>
+        #         <xsd:enumeration value="GRIB-2"/>
+        #         <xsd:enumeration value="HDF4"/>
+        #         <xsd:enumeration value="HDF5"/>
+        #         <xsd:enumeration value="McIDAS-AREA"/>
+        #         <xsd:enumeration value="NcML"/>
+        # 		  <xsd:enumeration value="NetCDF"/>
+        # 		  <xsd:enumeration value="NetCDF-4"/>
+        #         <xsd:enumeration value="NEXRAD2"/>
+        #         <xsd:enumeration value="NIDS"/>
+        #
+        #         <xsd:enumeration value="image/gif"/>
+        #         <xsd:enumeration value="image/jpeg"/>
+        #         <xsd:enumeration value="image/tiff"/>
+        #         <xsd:enumeration value="text/csv"/>
+        #         <xsd:enumeration value="text/html"/>
+        # 		  <xsd:enumeration value="text/plain"/>
+        # 		  <xsd:enumeration value="text/tab-separated-values"/>
+        #         <xsd:enumeration value="text/xml"/>
+        #         <xsd:enumeration value="video/mpeg"/>
+        #         <xsd:enumeration value="video/quicktime"/>
+        #         <xsd:enumeration value="video/realtime"/>
+        #       </xsd:restriction>
+        #     </xsd:simpleType>
+        #   </xsd:union>
+        #
+        # name="mimeType"
+        #   <xsd:restriction base="xsd:token">
+        #     <xsd:annotation>
+        #       <xsd:documentation>any valid mime type
+        #         (see http://www.iana.org/assignments/media-types/)
+        #       </xsd:documentation>
+        #     </xsd:annotation>
+        #   </xsd:restriction>
+        #   NOTE: to see if mimetype is valude, check against
+        #         mimetypes.types_map.values
+        #
+        type_name = "dataFormat"
+        valid = self._valid[type_name]
+        val = element.text
+        if val not in valid:
+            msg = "Value {} not valid for type {}: ".format(val, type_name)
+            msg = msg + " must be {}".format(valid)
+            logging.warning(msg)
+        return {type_name: val}
+
+    def handle_dataType(self, element):  # noqa
+        # name="dataTypes"
+        #   <xsd:union memberTypes="xsd:token">
+        #     <xsd:simpleType>
+        #       <xsd:restriction base="xsd:token">
+        #         <xsd:enumeration value="Grid"/>
+        #         <xsd:enumeration value="Image"/>
+        #         <xsd:enumeration value="Point"/>
+        #         <xsd:enumeration value="Radial"/>
+        #         <xsd:enumeration value="Station"/>
+        #         <xsd:enumeration value="Swath"/>
+        #         <xsd:enumeration value="Trajectory"/>
+        #       </xsd:restriction>
+        #     </xsd:simpleType>
+        #   </xsd:union>
+        type_name = "dataType"
+        valid = self._valid[type_name]
+        # case insensitive
+
+        val = element.text
+        if val.lower() not in valid:
+            msg = "Value {} not valid for type {}: ".format(val, type_name)
+            msg = msg + " must be {}".format(valid)
+            logging.warning(msg)
+        return {type_name: val}
+
+
+class _ComplexTypes(object):
+
+    def _spatial_range_req_children(self):
+        req = ["start",
+               "size"]
+        return req
+
+    def _spatial_range_opt_children(self):
+        opt = ["resolution",
+               "units"]
+        return opt
+
+    def _date_type_formatted_valid_attrs(self):
+        return ["format", "type"]
+
+    def _controlled_vocatulary_opt_attrs(self):
+        return ["vocabulary"]
+
+    def _variable_opt_attrs(self):
+        return ["vocabulary_name", "units"]
+
+    def _variable_req_attrs(self):
+        return ["name"]
+
+    def _variables_opt_attrs(self):
+        return ["vocabulary"]
+
+    def _data_size_req_attrs(self):
+        return ["units"]
+
+    #
+    # complex types:
+    # ==============
+    def handle_spatialRange(self, element):  # noqa
+        # name="spatialRange">
+        #   <xsd:sequence>
+        #    <xsd:element name="start" type="xsd:double"  />
+        #    <xsd:element name="size" type="xsd:double" />
+        #    <xsd:element name="resolution" type="xsd:double" minOccurs="0" />
+        #    <xsd:element name="units" type="xsd:string" minOccurs="0" />
+        #   </xsd:sequence>
+        type_name = "spatialRange"
+        req_children = self._spatial_range_req_children()
+        opt_children = self._spatial_range_opt_children()
+        valid = req_children + opt_children
+
+        spatial_range = {}
+        for child in element:
+            child_name = child.tag
+            if child_name in valid:
+                if child_name != "units":
+                    spatial_range[child.tag] = float(child.text)
+                else:
+                    spatial_range[child.tag] = child.text
+            else:
+                # child not valid
+                msg = "{} is not valid for type {}: ".format(child_name,
+                                                             type_name)
+                logging.warning(msg)
+        return spatial_range
+
+    def handle_controlledVocabulary(self, element):  # noqa
+        #
+        # type="controlledVocabulary"
+        #   <xsd:simpleContent>
+        #    <xsd:extension base="xsd:string">
+        #     <xsd:attribute name="vocabulary" type="xsd:string" />
+        #    </xsd:extension>
+        #   </xsd:simpleContent>
+        #
+        type_name = "controlledVocabulary"
+
+        opt_attrs = self._controlled_vocatulary_opt_attrs()
+        val = {}
+        for attr in opt_attrs:
+            if attr not in element.attrib:
+                msg = "{} must have an attribute: {}".format(type_name,
+                                                             attr)
+                logging.warning(msg)
+            else:
+                val[attr] = element.attrib[attr]
+
+        name = element.text
+        tmp = {"name": name}
+        if val:
+            tmp.update(val)
+        return tmp
+
+    def handle_dateTypeFormatted(self, element):  # noqa
+        # name="dateTypeFormatted"
+        #   <xsd:simpleContent>
+        #     <xsd:extension base="dateType">
+        #       <xsd:attribute name="format" type="xsd:string" /> // from
+        #                                        java.text.SimpleDateFormat
+        #       <xsd:attribute name="type" type="dateEnumTypes" />
+        #     </xsd:extension>
+        #
+        type_name = "dateTypeFormatted"
+        valid_attrs = self._date_type_formatted_valid_attrs()
+        val = {}
+        for attr in element.attrib:
+            if attr not in valid_attrs:
+                msg = "{} is not a valid attribute for {}".format(attr,
+                                                                  type_name)
+                logging.warning(msg)
+            else:
+                val[attr] = element.attrib[attr]
+
+        val["value"] = element.text
+
+        return val
+
+    def handle_sourceType(self, element):  # noqa
+        # name="sourceType"
+        #   <xsd:sequence>
+        #     <xsd:element name="name" type="controlledVocabulary"/>
+        #     <xsd:element name="contact">
+        #       <xsd:complexType>
+        #         <xsd:attribute name="email" type="xsd:string"
+        #                                     use="required"/>
+        #         <xsd:attribute name="url" type="xsd:anyURI"/>
+        #       </xsd:complexType>
+        #     </xsd:element>
+        #   </xsd:sequence>
+        parsed = {}
+        for child in element:
+            value = {}
+            if child.tag == "name":
+                value = self.handle_controlledVocabulary(child)
+            elif child.tag == "contact":
+                if "url" in child.attrib:
+                    value["url"] = child.attrib["url"]
+                if "email" in child.attrib:
+                    value["email"] = child.attrib["email"]
+                else:
+                    msg = "{} must have an attribute: {}".format("contact",
+                                                                 "email")
+                    logging.warning(msg)
+                    value["email"] = "missing"
+            if value:
+                parsed.update(value)
+        return parsed
+
+    def handle_timeCoverageType(self, element):  # noqa
+        # name="timeCoverageType">
+        #   <xsd:sequence>
+        #     <xsd:choice minOccurs="2" maxOccurs="3" >
+        #       <xsd:element name="start" type="dateTypeFormatted"/>
+        #       <xsd:element name="end" type="dateTypeFormatted"/>
+        #       <xsd:element name="duration" type="duration"/>
+        #     </xsd:choice>
+        #     <xsd:element name="resolution" type="duration" minOccurs="0"/>
+        #   </xsd:sequence>
+        parsed = {}
+        tags = []
+        for child in element:
+            tags.append(child.tag)
+        valid_num_elements = len(tags) >= 2 & len(tags) <= 3
+        if valid_num_elements:
+            for child in element:
+                value = {}
+                if child.tag in ["start", "end"]:
+                    processed = self.handle_dateTypeFormatted(child)
+                    value[child.tag] = processed["value"]
+                elif child.tag in ["duration", "resolution"]:
+                    value[child.tag] = child.text
+                parsed.update(value)
+        else:
+            msg = "Not enough elements to make a valid timeCoverage"
+            logging.warning(msg)
+
+        return parsed
+
+    def handle_variable(self, element):
+        # element_name="variable"
+        #   <xsd:complexType mixed="true">
+        #     <xsd:attribute name="name" type="xsd:string" use="required"/>
+        #     <xsd:attribute name="vocabulary_name" type="xsd:string"
+        #                    use="optional"/>
+        #     <xsd:attribute name="units" type="xsd:string"/>
+        #   </xsd:complexType>
+        type_name = "variable"
+        opt_attrs = self._variable_opt_attrs()
+        req_attrs = self._variable_req_attrs()
+        valid_attrs = opt_attrs + req_attrs
+        valid = True
+        for req_attr in req_attrs:
+            if req_attr not in element.attrib:
+                valid = False
+                msg = "{} must have an attribute {}".format(type_name,
+                                                            req_attr)
+                logging.warning(msg)
+            variable = {}
+        if valid:
+            if element.text:
+                variable["description"] = element.text
+            for attr in element.attrib:
+                if attr in valid_attrs:
+                    variable[attr] = element.attrib[attr]
+
+        return variable
+
+    def handle_variableMap(self, element):  # noqa
+        # element_name="variableMap"
+        #   <xsd:complexType>
+        #     <xsd:attributeGroup ref="XLink"/>
+        #   </xsd:complexType>
+        type_name = "variableMap"  # noqa
+        var_map = {}
+        for attr in element.attrib:
+            var_map[attr] = element.attrib[attr]
+
+        return var_map
+
+    def handle_variables(self, element):
+        # element_name="variables"
+        #   <xsd:complexType>
+        #     <xsd:choice>
+        #       <xsd:element ref="variable" minOccurs="0"
+        #                    maxOccurs="unbounded"/>
+        #       <xsd:element ref="variableMap" minOccurs="0"/>
+        #     </xsd:choice>
+        #     <xsd:attribute name="vocabulary" type="variableNameVocabulary"
+        #                    use="optional"/>
+        #     <xsd:attributeGroup ref="XLink"/>
+        #   </xsd:complexType>
+        type_name = "variables"  # noqa
+        variables = {}
+        variable_list = []
+        variable_map_list = []
+        for child in element:
+            child_type = child.tag
+            if child_type == "variable":
+                var = self.handle_variable(child)
+                variable_list.append(var)
+            elif child_type == "variableMap":
+                var_map = self.handle_variableMap(element)
+                variable_map_list.append(var_map)
+
+        opt_attrs = self._variables_opt_attrs()
+        for attr in element.attrib:
+            if attr in opt_attrs:
+                variables[attr] = element.attrib[attr]
+
+        if variable_list:
+            variables["variables"] = variable_list
+
+        if variable_map_list:
+            variables["variableMaps"] = variable_map_list
+        return variables
+
+    def handle_dataSize(self, element):  # noqa
+        #   <xsd:complexType>
+        #     <xsd:simpleContent>
+        #     <xsd:extension base="xsd:string">
+        #       <xsd:attribute name="units" type="xsd:string" use="required"/>
+        #     </xsd:extension>
+        #     </xsd:simpleContent>
+        #   </xsd:complexType>
+        #
+        req_attrs = self._data_size_req_attrs()
+        data_size = {}
+        data_size["size"] = float(element.text)
+
+        for attr in element.attrib:
+            if attr in req_attrs:
+                data_size[attr] = element.attrib[attr]
+
+        return data_size
+
+
+class TDSCatalogMetadata(object):
+
+    r"""
+    An object for holding information contained in the catalog Metadata.
+
+
+    Attributes
+    ----------
+    name : metadata
+        The dictionary containing the metadata enteries
+
+    """
+
+    def __init__(self, element, metadata_in=None):
+        r"""
+        Initialize a TDSCatalogMetadata object.
+
+        Parameters
+        ----------
+        metadata_node : Element
+            An Element Tree Element representing a metadata node
+
+        """
+        self._ct = _ComplexTypes()
+        self._st = _SimpleTypes()
+        self._sts = _SimpleTypes.__dict__
+        self._cts = _ComplexTypes.__dict__
+
+        inherited = False
+        if 'inherited' in element.attrib:
+            inherited = element.attrib['inherited']
+            if inherited == 'true':
+                inherited = True
+            else:
+                inherited = False
+
+        if metadata_in and inherited:
+            # only inherit metadata passed in if the new metadata
+            # element has inherit set to True
+            self.metadata = metadata_in
+        else:
+            self.metadata = {}
+            self.metadata["inherited"] = inherited
+
+        element_name = self._get_tag_name(element)
+        if element_name == "metadata":
+            for child in element:
+                self._parse_element(child)
+        else:
+            self._parse_element(element)
+
+    def _get_tag_name(self, element):
+        if "}" in element.tag:
+            element_name = element.tag.split('}')[-1]
+        else:
+            element_name = element.tag
+        return element_name
+
+    def _get_handler(self, handler_name):
+        handler_name = "handle_" + handler_name
+        if handler_name in self._cts:
+            handler = getattr(self._ct, handler_name)
+        elif handler_name in self._sts:
+            handler = getattr(self._st,  handler_name)
+        else:
+            msg = "cannot find handler for element {}".format(handler_name)
+            logging.error(msg)
+
+        return handler
+
+    def _parse_element(self, element):
+
+        element_name = self._get_tag_name(element)
+
+        parser = {"documentation": self._parse_documentation,
+                  "property": self._parse_property,
+                  "contributor": self._parse_contributor,
+                  "geospatialCoverage": self._parse_geospatial_coverage,
+                  "serviceName": self._parse_service_name,
+                  "authority": self._parse_authority,
+                  "publisher": self._parse_publisher,
+                  "creator": self._parse_creator,
+                  "keyword": self._parse_keyword,
+                  "project": self._parse_project,
+                  "dataFormat": self._parse_data_format,
+                  "dataType": self._parse_data_type,
+                  "date": self._parse_date,
+                  "timeCoverage": self._parse_timeCoverage,
+                  "variableMap": self._parse_variableMap}
+
+        try:
+            parser[element_name](element)
+        except KeyError:
+            msg = "no parser found for element {}".format(element_name)
+            logging.error(msg)
+            print(msg)
+            raise
+
+    def _parse_documentation(self, element):
+        # <xsd:simpleType name="documentationEnumTypes">
+        #  <xsd:union memberTypes="xsd:token">
+        #   <xsd:simpleType>
+        #    <xsd:restriction base="xsd:token">
+        #     <xsd:enumeration value="funding"/>
+        #     <xsd:enumeration value="history"/>
+        #     <xsd:enumeration value="processing_level"/>
+        #     <xsd:enumeration value="rights"/>
+        #     <xsd:enumeration value="summary"/>
+        #    </xsd:restriction>
+        #   </xsd:simpleType>
+        #  </xsd:union>
+        # </xsd:simpleType>
+        #
+        # <xsd:complexType name="documentationType" mixed="true">
+        #  <xsd:sequence>
+        #   <xsd:any namespace="http://www.w3.org/1999/xhtml" minOccurs="0"
+        #         maxOccurs="unbounded" processContents="strict"/>
+        #  </xsd:sequence>
+        #  <xsd:attribute name="type" type="documentationEnumTypes"/>
+        #  <xsd:attributeGroup ref="XLink" />
+        # </xsd:complexType>
+        xlink_href_attr = '{http://www.w3.org/1999/xlink}href'
+        xlink_title_attr = '{http://www.w3.org/1999/xlink}title'
+
+        # doc_enum_types = ("funding", "history", "processing_level", "rights",
+        #                  "summary")
+        known = 'type' in element.attrib
+        # document element has no attributes
+        plain_doc = not element.attrib
+        md = self.metadata
+        md.setdefault("documentation", {})
+        if known or plain_doc:
+            if known:
+                doc_type = element.attrib['type']
+            else:
+                doc_type = "generic"
+            md["documentation"].setdefault(doc_type, []).append(element.text)
+        elif xlink_href_attr in element.attrib:
+            title = element.attrib[xlink_title_attr]
+            href = element.attrib[xlink_href_attr]
+            xlink = {"title": title, "href": href}
+            md["documentation"].setdefault('xlink', []).append(xlink)
+        self.metadata = md
+
+    def _parse_property(self, element):
+        # <xsd:element name="property">
+        #  <xsd:complexType>
+        #   <xsd:attribute name="name" type="xsd:string"/>
+        #   <xsd:attribute name="value" type="xsd:string"/>
+        #  </xsd:complexType>
+        # </xsd:element>
+        name = element.attrib["name"]
+        value = element.attrib["value"]
+        self.metadata.setdefault("property", {})[name] = value
+
+    def _parse_contributor(self, element):
+        # <xsd:element name="contributor">
+        #   <xsd:complexType>
+        #     <xsd:simpleContent>
+        #       <xsd:extension base="xsd:string">
+        #         <xsd:attribute name="role" type="xsd:string"
+        #                        use="required"/>
+        #       </xsd:extension>
+        #     </xsd:simpleContent>
+        #   </xsd:complexType>
+        # </xsd:element>
+        element_type = "contributor"
+        role = element.attrib["role"]
+        name = element.text
+        self.metadata.setdefault(element_type, {})
+        self.metadata[element_type].setdefault(role, []).append(name)
+
+    def _parse_geospatial_coverage(self, element):
+        element_type = "geospatialCoverage"
+        self.metadata.setdefault(element_type, [])
+        md = {}
+        # <xsd:element name="geospatialCoverage">
+        #  <xsd:complexType>
+        #   <xsd:sequence>
+        #    <xsd:element name="northsouth" type="spatialRange"
+        #                 minOccurs="0" />
+        #    <xsd:element name="eastwest" type="spatialRange"
+        #                 minOccurs="0" />
+        #    <xsd:element name="updown" type="spatialRange"
+        #                 minOccurs="0" />
+        #    <xsd:element name="name" type="controlledVocabulary"
+        #                 minOccurs="0" maxOccurs="unbounded"/>
+        #   </xsd:sequence>
+        #
+        #   <xsd:attribute name="zpositive" type="upOrDown" default="up"/>
+        #  </xsd:complexType>
+        # </xsd:element>
+        elements = {"northsouth": "spatialRange",
+                    "eastwest": "spatialRange",
+                    "updown": "spatialRange",
+                    "name": "controlledVocabulary"
+                    }
+        attrs = {"zpositive": "upOrDown"}
+
+        if element.attrib:
+            for attr in element.attrib:
+                if attr in attrs:
+                    handler_name = attrs[attr]
+                    handler = self._get_handler(handler_name)
+                    value = handler(element)
+                    md.update({attr: value})
+                else:
+                    msg = "Attr on {} : {} not captured".format(attr,
+                                                                element_type)
+                    logging.warning(msg)
+
+        for child in element:
+            child_name = child.tag
+            if child_name in elements:
+                handler_name = elements[child_name]
+                handler = self._get_handler(handler_name)
+                value = handler(child)
+                md.update(value)
+
+        self.metadata[element_type].append(md)
+
+    def _parse_service_name(self, element):
+        # can only have one serviceName
+        element_type = "serviceName"
+        self.metadata[element_type] = element.text
+
+    def _parse_authority(self, element):
+        element_type = "authority"
+        self.metadata.setdefault(element_type, [])
+        self.metadata[element_type].append(element.text)
+
+    def _parse_publisher(self, element):
+        element_type = "publisher"
+        self.metadata.setdefault(element_type, [])
+        parsed = self._ct.handle_sourceType(element)
+        self.metadata[element_type].append(parsed)
+
+    def _parse_creator(self, element):
+        element_type = "creator"
+        self.metadata.setdefault(element_type, [])
+        parsed = self._ct.handle_sourceType(element)
+        self.metadata[element_type].append(parsed)
+
+    def _parse_keyword(self, element):
+        element_type = "keyword"
+        self.metadata.setdefault(element_type, [])
+        parsed = self._ct.handle_controlledVocabulary(element)
+        self.metadata[element_type].append(parsed)
+
+    def _parse_project(self, element):
+        element_type = "project"
+        self.metadata.setdefault(element_type, [])
+        parsed = self._ct.handle_controlledVocabulary(element)
+        self.metadata[element_type].append(parsed)
+
+    def _parse_data_format(self, element):
+        element_type = "dataFormat"  # noqa
+        parsed = self._st.handle_dataFormat(element)
+        self.metadata.update(parsed)
+
+    def _parse_data_type(self, element):
+        element_type = "dataType"  # noqa
+        parsed = self._st.handle_dataType(element)
+        self.metadata.update(parsed)
+
+    def _parse_date(self, element):
+        element_type = "date"
+        parsed = self._ct.handle_dateTypeFormatted(element)
+        self.metadata.setdefault(element_type, [])
+        self.metadata[element_type].append(parsed)
+
+    def _parse_timeCoverage(self, element):  # noqa
+        element_type = "timeCoverage"
+        parsed = self._ct.handle_timeCoverageType(element)
+        self.metadata.setdefault(element_type, [])
+        self.metadata[element_type].append(parsed)
+
+    def _parse_variableMap(self, element):  # noqa
+        element_type = "variableMap"
+        parsed = self._ct.handle_variableMap(element)
+        self.metadata.setdefault(element_type, [])
+        self.metadata[element_type].append(parsed)

--- a/siphon/tests/fixtures/top_level_20km_rap_catalog
+++ b/siphon/tests/fixtures/top_level_20km_rap_catalog
@@ -1,0 +1,310 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [thredds.ucar.edu]
+      User-Agent: [siphon (None)]
+    method: GET
+    uri: http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/catalog.xml
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<catalog
+        xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"
+        name=\"NAM CONUS 20km\" version=\"1.0.1\">\r\n  <service name=\"latest\" serviceType=\"Resolver\"
+        base=\"\" />\r\n  <service name=\"VirtualServices\" serviceType=\"Compound\"
+        base=\"\">\r\n    <service name=\"opendap\" serviceType=\"OPENDAP\" base=\"/thredds/dodsC/\"
+        />\r\n    <service name=\"wcs\" serviceType=\"WCS\" base=\"/thredds/wcs/\"
+        />\r\n    <service name=\"wms\" serviceType=\"WMS\" base=\"/thredds/wms/\"
+        />\r\n    <service name=\"ncss\" serviceType=\"NetcdfSubset\" base=\"/thredds/ncss/\"
+        />\r\n    <service name=\"cdmremote\" serviceType=\"CdmRemote\" base=\"/thredds/cdmremote/\"
+        />\r\n    <service name=\"ncml\" serviceType=\"NCML\" base=\"/thredds/ncml/\"
+        />\r\n    <service name=\"uddc\" serviceType=\"UDDC\" base=\"/thredds/uddc/\"
+        />\r\n    <service name=\"iso\" serviceType=\"ISO\" base=\"/thredds/iso/\"
+        />\r\n  </service>\r\n  <dataset name=\"NAM CONUS 20km\" harvest=\"true\">\r\n
+        \   <metadata inherited=\"true\">\r\n      <serviceName>VirtualServices</serviceName>\r\n
+        \     <authority>edu.ucar.unidata</authority>\r\n      <dataType>GRID</dataType>\r\n
+        \     <dataFormat>GRIB-1</dataFormat>\r\n      <documentation type=\"summary\">Model
+        runs are made at 00Z, and 12Z with analysis and forecasts every 3 hours out
+        to 60 hours; and at 06Z, and 18Z with analysis and forecasts every 3 hours
+        out to 48 hours. Vertical = surface, height above ground, and 1000 to 30 hPa
+        pressure levels.</documentation>\r\n      <documentation type=\"summary\">NCEP
+        Nonhydrostatic Mesoscale Model (NMM) and Gridpoint Statistical Interpolation
+        (GSI) analysis, running in the Weather Research and Forecasting (WRF) infrastructure.</documentation>\r\n
+        \     <documentation xlink:href=\"http://meted.ucar.edu/nwp/pcu2/NAMWRFjun2006.htm\"
+        xlink:title=\"COMET MetEd (Meteorology Education and Training) documentation\"
+        />\r\n      <documentation xlink:href=\"http://www.nco.ncep.noaa.gov/pmb/products/nam/\"
+        xlink:title=\"NCEP NAM product inventory\" />\r\n      <documentation xlink:href=\"http://www.emc.ncep.noaa.gov/modelinfo/index.html\"
+        xlink:title=\"NCEP Model documentation\" />\r\n      <documentation type=\"rights\">Freely
+        available</documentation>\r\n      <documentation type=\"processing_level\">Transmitted
+        through Unidata Internet Data Distribution.</documentation>\r\n      <documentation
+        type=\"processing_level\">Read by CDM Grib Collection.</documentation>\r\n
+        \     <documentation xlink:href=\"http://www.nco.ncep.noaa.gov/pmb/nwprod/analysis/\"
+        xlink:title=\"NCEP/NWS Model Analyses and Forecasts page\" />\r\n      <documentation
+        xlink:href=\"http://www.unidata.ucar.edu/data/index.html#model\" xlink:title=\"Unidata
+        IDD Model Data page\" />\r\n      <creator>\r\n        <name vocabulary=\"DIF\">DOC/NOAA/NWS/NCEP</name>\r\n
+        \       <contact url=\"http://www.ncep.noaa.gov/\" email=\"http://www.ncep.noaa.gov/mail_liaison.shtml\"
+        />\r\n      </creator>\r\n      <creator>\r\n        <name vocabulary=\"ADN\">National
+        Oceanic and Atmospheric Administration (NOAA)/National Weather Service (NWS)\r\n
+        \         National Center for Environmental Prediction (NCEP)</name>\r\n        <contact
+        url=\"http://www.ncep.noaa.gov/\" email=\"http://www.ncep.noaa.gov/mail_liaison.shtml\"
+        />\r\n      </creator>\r\n      <property name=\"Originating_or_generating_Center\"
+        value=\"US National Weather Service, National Centres for Environmental Prediction
+        (NCEP)\" />\r\n      <property name=\"Originating_or_generating_Subcenter\"
+        value=\"0\" />\r\n      <property name=\"GRIB_table_version\" value=\"0,2\"
+        />\r\n      <property name=\"Generating_process_or_model\" value=\"MESO NAM
+        Model (currently 12 km)\" />\r\n      <property name=\"file_format\" value=\"GRIB-1\"
+        />\r\n      <property name=\"Conventions\" value=\"CF-1.6\" />\r\n      <property
+        name=\"history\" value=\"Read using CDM IOSP GribCollection v3\" />\r\n      <property
+        name=\"featureType\" value=\"GRID\" />\r\n      <publisher>\r\n        <name
+        vocabulary=\"DIF\">UCAR/UNIDATA</name>\r\n        <contact url=\"http://www.unidata.ucar.edu/\"
+        email=\"support@unidata.ucar.edu\" />\r\n      </publisher>\r\n      <publisher>\r\n
+        \       <name vocabulary=\"ADN\">University Corporation for Atmospheric Research
+        (UCAR)/Unidata</name>\r\n        <contact url=\"http://www.unidata.ucar.edu/\"
+        email=\"support@unidata.ucar.edu\" />\r\n      </publisher>\r\n      <timeCoverage>\r\n
+        \       <end>present</end>\r\n        <duration>45 days</duration>\r\n      </timeCoverage>\r\n
+        \     <variableMap xlink:href=\"/thredds/metadata/grib/NCEP/NAM/CONUS_20km/noaaport/collection?metadata=variableMap\"
+        xlink:title=\"variables\" />\r\n    </metadata>\r\n    <dataset name=\"Full
+        Collection (Reference / Forecast Time) Dataset\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/TwoD\"
+        urlPath=\"grib/NCEP/NAM/CONUS_20km/noaaport/TwoD\">\r\n      <documentation
+        type=\"summary\">Two time dimensions: reference and forecast; full access
+        to all GRIB records</documentation>\r\n      <metadata inherited=\"true\">\r\n
+        \       <geospatialCoverage>\r\n          <northsouth>\r\n            <start>12.190000534057615</start>\r\n
+        \           <size>45.20275051890929</size>\r\n            <units>degrees_north</units>\r\n
+        \         </northsouth>\r\n          <eastwest>\r\n            <start>-152.98469030768285</start>\r\n
+        \           <size>104.0296533835022</size>\r\n            <units>degrees_east</units>\r\n
+        \         </eastwest>\r\n        </geospatialCoverage>\r\n        <timeCoverage>\r\n
+        \         <start>2015-05-28T00:00:00Z</start>\r\n          <end>2015-06-14T00:00:00Z</end>\r\n
+        \       </timeCoverage>\r\n        <variableMap xlink:href=\"/thredds/metadata/grib/NCEP/NAM/CONUS_20km/noaaport/TwoD?metadata=variableMap\"
+        xlink:title=\"variables\" />\r\n      </metadata>\r\n    </dataset>\r\n    <dataset
+        name=\"Best NAM CONUS 20km Time Series\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/Best\"
+        urlPath=\"grib/NCEP/NAM/CONUS_20km/noaaport/Best\">\r\n      <documentation
+        type=\"summary\">Single time dimension: for each forecast time, use GRIB record
+        with smallest offset from reference time</documentation>\r\n      <metadata
+        inherited=\"true\">\r\n        <geospatialCoverage>\r\n          <northsouth>\r\n
+        \           <start>12.190000534057615</start>\r\n            <size>45.20275051890929</size>\r\n
+        \           <units>degrees_north</units>\r\n          </northsouth>\r\n          <eastwest>\r\n
+        \           <start>-152.98469030768285</start>\r\n            <size>104.0296533835022</size>\r\n
+        \           <units>degrees_east</units>\r\n          </eastwest>\r\n        </geospatialCoverage>\r\n
+        \       <timeCoverage>\r\n          <start>2015-05-28T00:00:00Z</start>\r\n
+        \         <end>2015-06-14T00:00:00Z</end>\r\n        </timeCoverage>\r\n        <variableMap
+        xlink:href=\"/thredds/metadata/grib/NCEP/NAM/CONUS_20km/noaaport/Best?metadata=variableMap\"
+        xlink:title=\"variables\" />\r\n      </metadata>\r\n    </dataset>\r\n    <dataset
+        name=\"Latest Collection for NAM CONUS 20km\" urlPath=\"latest.xml\">\r\n
+        \     <serviceName>latest</serviceName>\r\n    </dataset>\r\n    <catalogRef
+        xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150528_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150528_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150528_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150528_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150528_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150528_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150528_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150528_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150528_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150528_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150528_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150528_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150529_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150529_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150529_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150529_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150529_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150529_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150529_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150529_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150529_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150529_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150529_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150529_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150530_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150530_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150530_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150530_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150530_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150530_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150530_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150530_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150530_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150530_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150530_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150530_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150531_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150531_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150531_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150531_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150531_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150531_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150601_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150601_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150601_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150601_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150601_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150601_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150601_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150601_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150601_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150601_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150601_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150601_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150602_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150602_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150602_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150602_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150602_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150602_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150602_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150602_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150602_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150602_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150602_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150602_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150603_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150603_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150603_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150603_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150603_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150603_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150603_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150603_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150603_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150603_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150603_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150603_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150604_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150604_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150604_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150604_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150604_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150604_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150604_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150604_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150604_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150604_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150604_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150604_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150605_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150605_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150605_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150605_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150605_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150605_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150605_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150605_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150605_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150605_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150605_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150605_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150606_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150606_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150606_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150606_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150606_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150606_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150606_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150606_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150606_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150606_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150606_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150606_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150607_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150607_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150607_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150607_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150607_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150607_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150607_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150607_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150607_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150607_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150607_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150607_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150608_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150608_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150608_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150608_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150608_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150608_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150608_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150608_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150608_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150608_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150608_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150608_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150609_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150609_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150609_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150609_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150609_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150609_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150609_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150609_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150609_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150609_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150609_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150609_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150610_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150610_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150610_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150610_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150610_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150610_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150610_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150610_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150610_1200.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150610_1800.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150610_1800.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150610_1800.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_0000.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150611_0000.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_0000.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_0600.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150611_0600.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_0600.grib1\"
+        name=\"\" />\r\n    <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_1200.grib1/catalog.xml\"
+        xlink:title=\"NAM_CONUS_20km_noaaport_20150611_1200.grib1\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_1200.grib1\"
+        name=\"\" />\r\n  </dataset>\r\n</catalog>\r\n"}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [close]
+      content-language: [en]
+      content-type: [application/xml;charset=UTF-8]
+      date: ['Thu, 11 Jun 2015 15:21:50 GMT']
+      server: [Apache]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [close]
+      Host: [thredds.ucar.edu]
+      User-Agent: [siphon (None)]
+    method: GET
+    uri: http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/latest.xml
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<catalog
+        xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"
+        name=\"NAM_CONUS_20km_noaaport_20150611_1200.grib1\" version=\"1.0.1\">\r\n
+        \ <service name=\"VirtualServices\" serviceType=\"Compound\" base=\"\">\r\n
+        \   <service name=\"opendap\" serviceType=\"OPENDAP\" base=\"/thredds/dodsC/\"
+        />\r\n    <service name=\"wcs\" serviceType=\"WCS\" base=\"/thredds/wcs/\"
+        />\r\n    <service name=\"wms\" serviceType=\"WMS\" base=\"/thredds/wms/\"
+        />\r\n    <service name=\"ncss\" serviceType=\"NetcdfSubset\" base=\"/thredds/ncss/\"
+        />\r\n    <service name=\"cdmremote\" serviceType=\"CdmRemote\" base=\"/thredds/cdmremote/\"
+        />\r\n    <service name=\"ncml\" serviceType=\"NCML\" base=\"/thredds/ncml/\"
+        />\r\n    <service name=\"uddc\" serviceType=\"UDDC\" base=\"/thredds/uddc/\"
+        />\r\n    <service name=\"iso\" serviceType=\"ISO\" base=\"/thredds/iso/\"
+        />\r\n  </service>\r\n  <service name=\"fullServices\" serviceType=\"Compound\"
+        base=\"\">\r\n    <service name=\"opendap\" serviceType=\"OPENDAP\" base=\"/thredds/dodsC/\"
+        />\r\n    <service name=\"HTTPServer\" serviceType=\"HTTPServer\" base=\"/thredds/fileServer/\"
+        />\r\n    <service name=\"wcs\" serviceType=\"WCS\" base=\"/thredds/wcs/\"
+        />\r\n    <service name=\"wms\" serviceType=\"WMS\" base=\"/thredds/wms/\"
+        />\r\n    <service name=\"ncss\" serviceType=\"NetcdfSubset\" base=\"/thredds/ncss/\"
+        />\r\n    <service name=\"cdmremote\" serviceType=\"CdmRemote\" base=\"/thredds/cdmremote/\"
+        />\r\n    <service name=\"ncml\" serviceType=\"NCML\" base=\"/thredds/ncml/\"
+        />\r\n    <service name=\"uddc\" serviceType=\"UDDC\" base=\"/thredds/uddc/\"
+        />\r\n    <service name=\"iso\" serviceType=\"ISO\" base=\"/thredds/iso/\"
+        />\r\n  </service>\r\n  <dataset name=\"NAM_CONUS_20km_noaaport_20150611_1200.grib1\"
+        harvest=\"true\" ID=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_1200.grib1\"
+        urlPath=\"grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_1200.grib1\">\r\n
+        \   <documentation type=\"summary\">Single reference time Grib Collection</documentation>\r\n
+        \   <metadata inherited=\"true\">\r\n      <serviceName>fullServices</serviceName>\r\n
+        \     <authority>edu.ucar.unidata</authority>\r\n      <dataType>GRID</dataType>\r\n
+        \     <dataFormat>GRIB-1</dataFormat>\r\n      <documentation type=\"summary\">Model
+        runs are made at 00Z, and 12Z with analysis and forecasts every 3 hours out
+        to 60 hours; and at 06Z, and 18Z with analysis and forecasts every 3 hours
+        out to 48 hours. Vertical = surface, height above ground, and 1000 to 30 hPa
+        pressure levels.</documentation>\r\n      <documentation type=\"summary\">NCEP
+        Nonhydrostatic Mesoscale Model (NMM) and Gridpoint Statistical Interpolation
+        (GSI) analysis, running in the Weather Research and Forecasting (WRF) infrastructure.</documentation>\r\n
+        \     <documentation xlink:href=\"http://meted.ucar.edu/nwp/pcu2/NAMWRFjun2006.htm\"
+        xlink:title=\"COMET MetEd (Meteorology Education and Training) documentation\"
+        />\r\n      <documentation xlink:href=\"http://www.nco.ncep.noaa.gov/pmb/products/nam/\"
+        xlink:title=\"NCEP NAM product inventory\" />\r\n      <documentation xlink:href=\"http://www.emc.ncep.noaa.gov/modelinfo/index.html\"
+        xlink:title=\"NCEP Model documentation\" />\r\n      <documentation type=\"rights\">Freely
+        available</documentation>\r\n      <documentation type=\"processing_level\">Transmitted
+        through Unidata Internet Data Distribution.</documentation>\r\n      <documentation
+        type=\"processing_level\">Read by CDM Grib Collection.</documentation>\r\n
+        \     <documentation xlink:href=\"http://www.nco.ncep.noaa.gov/pmb/nwprod/analysis/\"
+        xlink:title=\"NCEP/NWS Model Analyses and Forecasts page\" />\r\n      <documentation
+        xlink:href=\"http://www.unidata.ucar.edu/data/index.html#model\" xlink:title=\"Unidata
+        IDD Model Data page\" />\r\n      <documentation type=\"Reference Time\">2015-06-11T12:00:00Z</documentation>\r\n
+        \     <creator>\r\n        <name vocabulary=\"DIF\">DOC/NOAA/NWS/NCEP</name>\r\n
+        \       <contact url=\"http://www.ncep.noaa.gov/\" email=\"http://www.ncep.noaa.gov/mail_liaison.shtml\"
+        />\r\n      </creator>\r\n      <creator>\r\n        <name vocabulary=\"ADN\">National
+        Oceanic and Atmospheric Administration (NOAA)/National Weather Service (NWS)\r\n
+        \         National Center for Environmental Prediction (NCEP)</name>\r\n        <contact
+        url=\"http://www.ncep.noaa.gov/\" email=\"http://www.ncep.noaa.gov/mail_liaison.shtml\"
+        />\r\n      </creator>\r\n      <property name=\"Originating_or_generating_Center\"
+        value=\"US National Weather Service, National Centres for Environmental Prediction
+        (NCEP)\" />\r\n      <property name=\"Originating_or_generating_Subcenter\"
+        value=\"0\" />\r\n      <property name=\"GRIB_table_version\" value=\"0,2\"
+        />\r\n      <property name=\"Generating_process_or_model\" value=\"MESO NAM
+        Model (currently 12 km)\" />\r\n      <property name=\"file_format\" value=\"GRIB-1\"
+        />\r\n      <property name=\"Conventions\" value=\"CF-1.6\" />\r\n      <property
+        name=\"history\" value=\"Read using CDM IOSP GribCollection v3\" />\r\n      <property
+        name=\"featureType\" value=\"GRID\" />\r\n      <publisher>\r\n        <name
+        vocabulary=\"DIF\">UCAR/UNIDATA</name>\r\n        <contact url=\"http://www.unidata.ucar.edu/\"
+        email=\"support@unidata.ucar.edu\" />\r\n      </publisher>\r\n      <publisher>\r\n
+        \       <name vocabulary=\"ADN\">University Corporation for Atmospheric Research
+        (UCAR)/Unidata</name>\r\n        <contact url=\"http://www.unidata.ucar.edu/\"
+        email=\"support@unidata.ucar.edu\" />\r\n      </publisher>\r\n      <geospatialCoverage>\r\n
+        \       <northsouth>\r\n          <start>12.190000534057615</start>\r\n          <size>45.20275051890929</size>\r\n
+        \         <units>degrees_north</units>\r\n        </northsouth>\r\n        <eastwest>\r\n
+        \         <start>-152.98469030768285</start>\r\n          <size>104.0296533835022</size>\r\n
+        \         <units>degrees_east</units>\r\n        </eastwest>\r\n      </geospatialCoverage>\r\n
+        \     <timeCoverage>\r\n        <start>2015-06-11T12:00:00Z</start>\r\n        <end>2015-06-14T00:00:00Z</end>\r\n
+        \     </timeCoverage>\r\n      <variableMap xlink:href=\"/thredds/metadata/grib/NCEP/NAM/CONUS_20km/noaaport/NAM_CONUS_20km_noaaport_20150611_1200.grib1?metadata=variableMap\"
+        xlink:title=\"variables\" />\r\n    </metadata>\r\n  </dataset>\r\n</catalog>\r\n"}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [close]
+      content-language: [en]
+      content-type: [application/xml;charset=UTF-8]
+      date: ['Thu, 11 Jun 2015 15:21:50 GMT']
+      server: [Apache]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+version: 1

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -22,10 +22,24 @@ class TestCatalog(object):
         ds = list(cat.datasets.values())[0]
         assert 'OPENDAP' in ds.access_urls
 
+    @recorder.use_cassette('top_level_20km_rap_catalog')
+    def test_virtual_access(self):
+        url = ('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/'
+               'CONUS_20km/noaaport/catalog.xml')
+        cat = TDSCatalog(url)
+        # find the 2D time coordinate "full collection" dataset
+        for dataset in list(cat.datasets.values()):
+            if "Full Collection" in dataset.name:
+                ds = dataset
+                break
+        assert 'OPENDAP' in ds.access_urls
+        # TwoD is a virtual dataset, so HTTPServer
+        # should not be listed here
+        assert 'HTTPServer' not in ds.access_urls
 
-@recorder.use_cassette('latest_rap_catalog')
-def test_get_latest():
-    url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
-           'grib/NCEP/RAP/CONUS_13km/catalog.xml')
-    latest_url = get_latest_access_url(url, "OPENDAP")
-    assert latest_url
+    @recorder.use_cassette('latest_rap_catalog')
+    def test_get_latest(self):
+        url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
+               'grib/NCEP/RAP/CONUS_13km/catalog.xml')
+        latest_url = get_latest_access_url(url, "OPENDAP")
+        assert latest_url

--- a/siphon/tests/test_metadata.py
+++ b/siphon/tests/test_metadata.py
@@ -1,0 +1,517 @@
+from siphon.metadata import TDSCatalogMetadata, _SimpleTypes, _ComplexTypes
+from nose.tools import assert_dict_equal, assert_equal
+import xml.etree.ElementTree as ET
+
+#
+# tested:
+#
+# threddsMetadataGroup:
+# =====================
+#
+# element_name="documentation" type="documentationType"
+# element_name="serviceName"   type="xsd:string"
+# element_name="authority"     type="xsd:string"
+#
+# simple types:
+# =============
+# name="upOrDown"
+# name="dataFormatTypes"
+# name="dataTypes"
+#
+# complex types:
+# ==============
+# name="spatialRange">
+# type="controlledVocabulary"
+# name="dateTypeFormatted"#
+# name="sourceType"
+# name="timeCoverageType">
+#
+# ref'd elements
+# ==============
+#
+# element_name="metadata"
+# element_name="geospatialCoverage"
+# element_name="property":
+# element_name="contributor"
+# element_name="variable"
+# element_name="variables"
+# element_name="variableMap"
+# element_name="dataSize"
+# element_name="publisher"
+# element_name="creator"
+# element_name="keyword"
+# element_name="project"
+# element_name="dataFormat"
+# element_name="date"
+# element_name="dataType"
+# element_name="date"
+# element_name="timeCoverage"
+
+
+class TestSimpleTypes(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.st = _SimpleTypes()
+
+    def test_up_or_down_valid(self):
+        xml = '<geospatialCoverage zpositive="down" />'
+        expected = {"zpositive": "down"}
+        element = ET.fromstring(xml)
+        assert element.attrib
+        val = self.st.handle_upOrDown(element)
+        assert_dict_equal(val, expected)
+
+    def test_data_format_type(self):
+        xml = '<dataFormat>NcML</dataFormat>'
+        expected = {"dataFormat": "NcML"}
+        element = ET.fromstring(xml)
+        assert not element.attrib
+        assert element.text
+        val = self.st.handle_dataFormat(element)
+        assert_dict_equal(expected, val)
+
+    def test_data_type(self):
+        xml = '<dataType>GRID</dataType>'
+        expected = {"dataType": "GRID"}
+        element = ET.fromstring(xml)
+
+        assert not element.attrib
+        assert element.text
+        val = self.st.handle_dataType(element)
+        assert_dict_equal(expected, val)
+
+
+class TestComplexTypes(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.st = _ComplexTypes()
+
+    def test_spatial_range_valid(self):
+        xml = '<northsouth><start>44.1</start>' \
+              '<size>20.6</size><units>degrees_north</units>' \
+              '</northsouth>'
+        expected = {"start": 44.1,
+                    "size": 20.6,
+                    "units": "degrees_north"}
+        element = ET.fromstring(xml)
+        actual = {}
+        for child in element:
+            actual.update(self.st.handle_spatialRange(element))
+
+        assert_dict_equal(actual, expected)
+
+    def test_controlled_vocabulary(self):
+        xml = '<name vocabulary="MyVocabName">' \
+              'NOAA and NCEP</name>'
+        expected = {"vocabulary": "MyVocabName",
+                    "name": "NOAA and NCEP"}
+        element = ET.fromstring(xml)
+        actual = self.st.handle_controlledVocabulary(element)
+        assert_dict_equal(expected, actual)
+
+    def test_date_type_formatted(self):
+        xml = '<start format="yyyy DDD" type="created">1999 189</start>'
+        expected = {"format": "yyyy DDD",
+                    "type": "created",
+                    "value": "1999 189"}
+        element = ET.fromstring(xml)
+        actual = self.st.handle_dateTypeFormatted(element)
+        assert_dict_equal(expected, actual)
+
+    def test_source_type(self):
+        xml = '<publisher><name vocabulary="DIF">UCAR/NCAR/CDP</name>' \
+              '<contact url="http://dataportal.ucar.edu" ' \
+              'email="cdp@ucar.edu"/></publisher>'
+
+        element = ET.fromstring(xml)
+        expected = {"vocabulary": "DIF",
+                    "name": "UCAR/NCAR/CDP",
+                    "email": "cdp@ucar.edu",
+                    "url": "http://dataportal.ucar.edu"}
+        actual = self.st.handle_sourceType(element)
+        assert_dict_equal(expected, actual)
+
+    def test_time_coverage_type1(self):
+        xml = '<timeCoverage><end>present</end><duration>10 days</duration>' \
+            '<resolution>15 minutes</resolution></timeCoverage>'
+        element = ET.fromstring(xml)
+        expected = {"end": "present",
+                    "duration": "10 days",
+                    "resolution": "15 minutes"}
+        actual = self.st.handle_timeCoverageType(element)
+        assert_dict_equal(expected, actual)
+
+    def test_time_coverage_type2(self):
+        xml = '<timeCoverage><start>1999-11-16T12:00:00</start>' \
+            '<end>present</end></timeCoverage>'
+        element = ET.fromstring(xml)
+        expected = {"end": "present",
+                    "start": "1999-11-16T12:00:00"}
+        actual = self.st.handle_timeCoverageType(element)
+        assert_dict_equal(expected, actual)
+
+    def test_time_coverage_type3(self):
+        xml = '<timeCoverage><start>1999-11-16T12:00:00</start>' \
+            '<duration>P3M</duration></timeCoverage>'
+        element = ET.fromstring(xml)
+        expected = {"duration": "P3M",
+                    "start": "1999-11-16T12:00:00"}
+        actual = self.st.handle_timeCoverageType(element)
+        assert_dict_equal(expected, actual)
+
+    def test_variable(self):
+        xml = '<variable name="wdir" vocabulary_name="Wind Direction" ' \
+              'units= "degrees">Wind Direction @ surface</variable>'
+        element = ET.fromstring(xml)
+        expected = {"name": "wdir",
+                    "vocabulary_name": "Wind Direction",
+                    "units": "degrees",
+                    "description": "Wind Direction @ surface"}
+        actual = self.st.handle_variable(element)
+        assert_dict_equal(expected, actual)
+
+    def test_variable2(self):
+        xml = '<variable name="wdir"></variable>'
+        element = ET.fromstring(xml)
+        expected = {"name": "wdir"}
+        actual = self.st.handle_variable(element)
+        assert_dict_equal(expected, actual)
+
+    def test_variable3(self):
+        xml = '<variable name="wdir">Wind Direction @ surface</variable>'
+        element = ET.fromstring(xml)
+        expected = {"name": "wdir",
+                    "description": "Wind Direction @ surface"}
+        actual = self.st.handle_variable(element)
+        assert_dict_equal(expected, actual)
+
+    def test_variable_map(self):
+        xml = '<variableMap xmlns:xlink="http://www.w3.org/1999/xlink" ' \
+              'xlink:href="../standardQ/Eta.xml" />'
+        element = ET.fromstring(xml)
+        expected = {
+            "{http://www.w3.org/1999/xlink}href": "../standardQ/Eta.xml"}
+        actual = self.st.handle_variableMap(element)
+        assert_dict_equal(expected, actual)
+
+    def test_variable_map2(self):
+        xml = '<variableMap xmlns:xlink="http://www.w3.org/1999/xlink" ' \
+              'xlink:href="../standardQ/Eta.xml" xlink:title="variables"/>'
+        element = ET.fromstring(xml)
+        expected = {"{http://www.w3.org/1999/xlink}href":
+                    "../standardQ/Eta.xml",
+                    "{http://www.w3.org/1999/xlink}title":
+                        "variables"}
+        actual = self.st.handle_variableMap(element)
+        assert_dict_equal(expected, actual)
+
+    def test_variables(self):
+        xml = '<variables vocabulary="CF-1.0">' \
+              '<variable name="wv" vocabulary_name="Wind Speed" ' \
+              'units="m/s">Wind Speed @ surface</variable>' \
+              '<variable name="wdir" vocabulary_name="Wind Direction" ' \
+              'units= "degrees">Wind Direction @ surface</variable>' \
+              '<variable name="o3c" vocabulary_name="Ozone Concentration"' \
+              ' units="g/g">Ozone Concentration @ surface</variable>' \
+              '</variables>'
+        element = ET.fromstring(xml)
+        actual = self.st.handle_variables(element)
+        assert "vocabulary" in actual
+        assert actual["vocabulary"] == "CF-1.0"
+        assert "variables" in actual
+        assert len(actual["variables"]) == 3
+        assert "variableMaps" not in actual
+
+    def test_variables2(self):
+        xml = '<variables vocabulary="GRIB-NCEP" ' \
+              ' xmlns:xlink="http://www.w3.org/1999/xlink" ' \
+              'xlink:href="http://www.unidata.ucar.edu/GRIB-NCEPtable2.xml">' \
+              '<variableMap xlink:href="../standardQ/Eta.xml" />' \
+              '</variables>'
+        element = ET.fromstring(xml)
+        actual = self.st.handle_variables(element)
+        assert "vocabulary" in actual
+        assert actual["vocabulary"] == "GRIB-NCEP"
+        assert "variables" not in actual
+        assert "variableMaps" in actual
+        assert len(actual["variableMaps"]) == 1
+
+    def test_data_size(self):
+        xml = '<dataSize units="Kbytes">123</dataSize>'
+        element = ET.fromstring(xml)
+        actual = self.st.handle_dataSize(element)
+        assert "units" in actual
+        assert actual["units"] == "Kbytes"
+        assert actual["size"] == 123
+
+
+class TestProperty(object):
+
+    @classmethod
+    def setup_class(cls):
+        xml = '<property name="Conventions" value="CF-1.6" />'
+        element = ET.fromstring(xml)
+        cls.md = TDSCatalogMetadata(element).metadata
+        cls.element_name = "property"
+
+    def test_prop(self):
+        assert self.element_name in self.md
+
+    def test_prop_not_empty(self):
+        for entry in self.md[self.element_name]:
+            assert entry
+
+
+class TestContributor:
+
+    @classmethod
+    def setup_class(cls):
+        xml = '<contributor role="PI">Jane Doe</contributor>'
+        element = ET.fromstring(xml)
+        cls.md = TDSCatalogMetadata(element).metadata
+        cls.element_name = "contributor"
+
+    def test_contributor(self):
+        assert self.element_name in self.md
+
+    def test_contributor_for_role_not_empty(self):
+        for entry in self.md[self.element_name]:
+            assert entry
+
+
+class TestGeospatialCoverage(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.element_name = "geospatialCoverage"
+
+        xml1 = '<geospatialCoverage zpositive="down">' \
+               '<northsouth>' \
+               '<start>10</start><size>80</size>' \
+               '<resolution>2</resolution>' \
+               '<units>degrees_north</units>' \
+               '</northsouth>' \
+               '<eastwest>' \
+               '<start>-130</start>' \
+               '<size>260</size>' \
+               '<resolution>2</resolution>' \
+               '<units>degrees_east</units>' \
+               '</eastwest>' \
+               '<updown>' \
+               '<start>0</start>' \
+               '<size>22</size>' \
+               '<resolution>0.5</resolution>' \
+               '<units>km</units>' \
+               '</updown>' \
+               '</geospatialCoverage>'
+
+        xml2 = '<geospatialCoverage>' \
+               '<name vocabulary="Thredds">global</name>' \
+               '</geospatialCoverage>'
+
+        cls.xml_warn1 = '<geospatialCoverage crazy="yep">' \
+            '</geospatialCoverage>'
+
+        cls.xml_warn2 = '<geospatialCoverage zpositive="waka-waka">' \
+            '</geospatialCoverage>'
+
+        cls.md1 = TDSCatalogMetadata(ET.fromstring(xml1)).metadata
+        cls.md2 = TDSCatalogMetadata(ET.fromstring(xml2)).metadata
+
+    def test_geospatial_coverage_attr1(self):
+        assert self.element_name in self.md1
+        for entry in self.md1[self.element_name]:
+            assert entry
+
+    def test_geospatial_coverage_attr2(self):
+        # can we detect this:
+        # <geospatialCoverage zpositive="down">
+        if self.md1[self.element_name]:
+            if "zpositive" in self.md1[self.element_name]:
+                possible_values = ["up", "down"]
+                value = self.md1[self.element_name]["zpositive"]
+                assert value in possible_values
+
+
+class TestMetadata(object):
+
+    def _make_element(self, xml_str):
+        return ET.fromstring(xml_str)
+
+    def test_documentation_element_no_type(self):
+        xml = '<documentation>Used in doubled CO2 scenario</documentation>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "documentation" in md
+        assert "generic" in md["documentation"]
+        assert len(md["documentation"]["generic"]) > 0
+        for entry in md["documentation"]["generic"]:
+            assert entry != []
+
+    def test_documentation_element_summary(self):
+        xml = '<documentation type="summary"> The SAGE III Ozone Loss and ' \
+              'Validation Experiment (SOLVE) was a measurement campaign ' \
+              'designed to examine the processes controlling ozone levels ' \
+              'at mid- to high high latitudes. Measurements were made in ' \
+              'the Arctic high-latitude region in winter using the NASA ' \
+              'DC-8 and ER-2 aircraft,as well as balloon platforms and ' \
+              'ground-based instruments. </documentation>'
+
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "documentation" in md
+        assert "summary" in md["documentation"]
+        assert len(md["documentation"]["summary"]) > 0
+        for entry in md["documentation"]["summary"]:
+            assert entry != []
+
+    def test_documentation_element_rights(self):
+        xml = '<documentation type="rights"> Users of these data files are ' \
+              'expected  to follow the NASA ESPO Archive guidelines for ' \
+              'use of the SOLVE data, including consulting with the PIs ' \
+              'of the individual measurements  for interpretation and ' \
+              'credit.</documentation>'
+
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "documentation" in md
+        assert "rights" in md["documentation"]
+        assert len(md["documentation"]["rights"]) > 0
+        for entry in md["documentation"]["rights"]:
+            assert entry != []
+
+    def test_documentation_element_processing_level(self):
+        xml = '<documentation type="processing_level"> Transmitted through ' \
+              'Unidata Internet Data Distribution.</documentation>'
+
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "documentation" in md
+        assert "processing_level" in md["documentation"]
+        assert len(md["documentation"]["processing_level"]) > 0
+        for entry in md["documentation"]["processing_level"]:
+            assert entry != []
+
+    def test_documentation_element_reference_time(self):
+        xml = '<documentation type="Reference Time">' \
+              '2015-05-28T12:00:00Z</documentation>'
+
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "documentation" in md
+        assert "Reference Time" in md["documentation"]
+        assert len(md["documentation"]["Reference Time"]) > 0
+        for entry in md["documentation"]["Reference Time"]:
+            assert entry != []
+
+    def test_documentation_element_xlink(self):
+        xml = '<documentation xmlns:xlink="http://www.w3.org/1999/xlink" ' \
+              'xlink:href="http://espoarchive.nasa.gov/archive/index.html" ' \
+              'xlink:title="Earth Science Project Office Archives"/>'
+
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "documentation" in md
+        assert "xlink" in md["documentation"]
+        assert len(md["documentation"]["xlink"]) > 0
+        for entry in md["documentation"]["xlink"]:
+            assert entry["title"]
+            assert entry["href"]
+
+    def test_service_type(self):
+        xml = '<serviceName>VirtualServices</serviceName>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "serviceName" in md
+        md["serviceName"] == "VirtualServices"
+
+    def test_authority(self):
+        xml = '<authority>edu.ucar.unidata</authority>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "authority" in md
+        assert_equal(len(md["authority"]), 1)
+        assert_equal(md["authority"][0], "edu.ucar.unidata")
+
+    def test_publisher(self):
+        xml = '<publisher><name vocabulary="DIF">UCAR/UNIDATA</name>' \
+              '<contact url="http://www.unidata.ucar.edu/" ' \
+              'email="support@unidata.ucar.edu"/>' \
+              '</publisher>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "publisher" in md
+        assert_equal(len(md["publisher"]), 1)
+        assert_equal(md["publisher"][0]["vocabulary"], "DIF")
+        assert_equal(md["publisher"][0]["name"], "UCAR/UNIDATA")
+        assert_equal(md["publisher"][0]["url"], "http://www.unidata.ucar.edu/")
+        assert_equal(md["publisher"][0]["email"], "support@unidata.ucar.edu")
+
+    def test_creator(self):
+        xml = '<creator><name vocabulary="DIF">DOC/NOAA/NWS/NCEP</name>' \
+              '<contact url="http://www.ncep.noaa.gov/" ' \
+              'email="http://www.ncep.noaa.gov/mail_liaison.shtml"/>' \
+              '</creator>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "creator" in md
+        assert_equal(len(md["creator"]), 1)
+        assert_equal(md["creator"][0]["vocabulary"], "DIF")
+        assert_equal(md["creator"][0]["name"], "DOC/NOAA/NWS/NCEP")
+        assert_equal(md["creator"][0]["url"], "http://www.ncep.noaa.gov/")
+        assert_equal(md["creator"][0]["email"],
+                     "http://www.ncep.noaa.gov/mail_liaison.shtml")
+
+    def test_keyword(self):
+        xml = "<keyword>Ocean Biomass</keyword>"
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "keyword" in md
+        assert_equal(len(md["keyword"]), 1)
+        assert_equal(md["keyword"][0]["name"], "Ocean Biomass")
+
+    def test_project(self):
+        xml = '<project vocabulary="DIF">NASA Earth Science Project Office, ' \
+              'Ames Research Center</project>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "project" in md
+        assert_equal(len(md["project"]), 1)
+        assert_equal(md["project"][0]["vocabulary"], "DIF")
+        assert_equal(md["project"][0]["name"],
+                     "NASA Earth Science Project Office, Ames Research Center")
+
+    def test_data_format(self):
+        xml = '<dataFormat>GRIB-1</dataFormat>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "dataFormat" in md
+        assert_equal(md["dataFormat"], "GRIB-1")
+
+    def test_data_type(self):
+        xml = '<dataType>GRID</dataType>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "dataType" in md
+        assert_equal(md["dataType"], "GRID")
+
+    def test_date(self):
+        xml = '<date type="modified">2015-06-11T02:09:52Z</date>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "date" in md
+        assert_equal(len(md["date"]), 1)
+        assert_equal(md["date"][0]["type"], "modified")
+        assert_equal(md["date"][0]["value"], "2015-06-11T02:09:52Z")
+
+    def test_time_coverage(self):
+        xml = '<timeCoverage><end>present</end><duration>45 days</duration>' \
+              '</timeCoverage>'
+        element = self._make_element(xml)
+        md = TDSCatalogMetadata(element).metadata
+        assert "timeCoverage" in md
+        assert_equal(len(md["timeCoverage"]), 1)
+        assert_equal(md["timeCoverage"][0]["end"], "present")
+        assert_equal(md["timeCoverage"][0]["duration"], "45 days")


### PR DESCRIPTION
Adds the ability to parse metadata blocks from TDS Client Catalogs, and only exposes services on a dataset that are defined by the ServiceName element contained in the metadata.