### PR TITLE
Preserve relative urls in catalog references

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -145,8 +145,6 @@ class CatalogRef(object):
         """
         self.name = element_node.attrib["name"]
         self.href = element_node.attrib["{http://www.w3.org/1999/xlink}href"]
-        if self.href[0] == '/':
-            self.href = self.href[1:]
         self.title = element_node.attrib["{http://www.w3.org/1999/xlink}title"]
 
 

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -4,6 +4,12 @@ import xml.etree.ElementTree as ET
 from .metadata import TDSCatalogMetadata
 from .http_util import create_http_session, urlopen
 
+try:
+    from urlparse import urljoin
+except ImportError:
+    # Python 3
+    from urllib.parse import urljoin
+
 log = logging.getLogger("siphon.catalog")
 log.setLevel(logging.WARNING)
 
@@ -104,7 +110,7 @@ class TDSCatalog(object):
             self.datasets[ds.name] = ds
 
     def _process_catalog_ref(self, element):
-        catalog_ref = CatalogRef(element)
+        catalog_ref = CatalogRef(self.catalog_url, element)
         self.catalog_refs[catalog_ref.title] = catalog_ref
 
     def _process_metadata(self, element, tag_type):
@@ -133,19 +139,30 @@ class CatalogRef(object):
     title : string
         Title of the catalogRef element
     """
-    def __init__(self, element_node):
+    def __init__(self, base_url, element_node):
         r"""
         Initialize the catalogRef object.
 
         Parameters
         ----------
+        base_url : String
+            URL to the base catalog that owns this reference
         element_node : Element
             An Element Tree Element representing a catalogRef node
 
         """
         self.name = element_node.attrib["name"]
-        self.href = element_node.attrib["{http://www.w3.org/1999/xlink}href"]
         self.title = element_node.attrib["{http://www.w3.org/1999/xlink}title"]
+
+        # Resolve relative URLs
+        href = element_node.attrib["{http://www.w3.org/1999/xlink}href"]
+        self.href = urljoin(base_url, href)
+
+    def follow(self):
+        r"""
+        Follow the reference, returning a new TDSCatalog
+        """
+        return TDSCatalog(self.href)
 
 
 class Dataset(object):

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -3,6 +3,8 @@ import logging
 from siphon.testing import get_recorder
 from siphon.catalog import TDSCatalog, get_latest_access_url
 
+from urlparse import urljoin
+
 log = logging.getLogger("siphon.catalog")
 log.setLevel(logging.WARNING)
 log.addHandler(logging.StreamHandler())
@@ -75,3 +77,11 @@ class TestCatalog(object):
                'grib/NCEP/RAP/CONUS_13km/catalog.html')
         cat = TDSCatalog(url)
         assert cat
+
+    def test_catalog_follow(self):
+        url = 'http://thredds-test.unidata.ucar.edu/thredds/testDatasets.xml'
+        ref_name = 'TestFmrc'
+        cat = TDSCatalog(url)
+        ref = cat.catalog_refs[ref_name]
+        ref_url = urljoin(cat.catalog_url, ref.href)
+        ref_cat = TDSCatalog(ref_url)

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -3,12 +3,6 @@ import logging
 from siphon.testing import get_recorder
 from siphon.catalog import TDSCatalog, get_latest_access_url
 
-try:
-    from urlparse import urljoin
-except ImportError:
-    # Python 3
-    from urllib.parse import urljoin
-
 log = logging.getLogger("siphon.catalog")
 log.setLevel(logging.WARNING)
 log.addHandler(logging.StreamHandler())
@@ -85,8 +79,5 @@ class TestCatalog(object):
     def test_catalog_follow(self):
         url = 'http://thredds-test.unidata.ucar.edu/thredds/testDatasets.xml'
         ref_name = 'TestFmrc'
-        cat = TDSCatalog(url)
-        ref = cat.catalog_refs[ref_name]
-        ref_url = urljoin(cat.catalog_url, ref.href)
-        ref_cat = TDSCatalog(ref_url)
-        assert ref_cat
+        cat = TDSCatalog(url).catalog_refs[ref_name].follow()
+        assert cat

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -3,7 +3,11 @@ import logging
 from siphon.testing import get_recorder
 from siphon.catalog import TDSCatalog, get_latest_access_url
 
-from urlparse import urljoin
+try:
+    from urlparse import urljoin
+except ImportError:
+    # Python 3
+    from urllib.parse import urljoin
 
 log = logging.getLogger("siphon.catalog")
 log.setLevel(logging.WARNING)
@@ -85,3 +89,4 @@ class TestCatalog(object):
         ref = cat.catalog_refs[ref_name]
         ref_url = urljoin(cat.catalog_url, ref.href)
         ref_cat = TDSCatalog(ref_url)
+        assert ref_cat


### PR DESCRIPTION
The leading '/' in catalog references is needed to construct the full URL path from a catalog reference.

For instance, in the catalog `http://thredds-test.unidata.ucar.edu/thredds/testDatasets.xml` the reference `TestFmrc` points to `/thredds/catalog/fmrc/ecmwf/global_2p5/catalog.xml`. Resolving the relative URL should give `http://thredds-test.unidata.ucar.edu/thredds/catalog/fmrc/ecmwf/global_2p5/catalog.xml`. Removing the `/`, as is being done in `CatalogRef.__init__()`, means the URL is constructed relative to the current catalog path, rather than being relative to the hostname.