### PR TITLE
Fix: ncss netcdf temp file permission error on Windows

### DIFF
--- a/siphon/ncss.py
+++ b/siphon/ncss.py
@@ -1,10 +1,10 @@
 import xml.etree.ElementTree as ET
+import atexit
 from io import BytesIO
+from os import remove
+import platform
 
 import numpy as np
-import os
-import platform
-import atexit
 
 from .http_util import DataQuery, HTTPEndPoint, parse_iso_date
 from .ncss_dataset import NCSSDataset
@@ -357,17 +357,6 @@ try:
                 tmp_file.flush()
                 return Dataset(tmp_file.name, 'r')
 
-# def temp_opener(name, flag, mode=0o777):
-#   return os.open(name, flag | os.O_TEMPORARY, mode)
-
-# with tempfile.NamedTemporaryFile() as f:
-#     f.write(DATA)
-#     f.flush()
-#     with open(f.name, "rb", opener=temp_opener) as f:
-#         assert f.read() == DATA
-
-# assert not os.path.exists(f.name) 
-
 except ImportError:
     import warnings
     warnings.warn('netCDF4 module not installed. '
@@ -375,7 +364,7 @@ except ImportError:
 
 def deletetempfile(fname):
     try:
-        os.remove(fname)
+        remove(fname)
     except PermissionError:
         import warnings
         warnings.warn('temporary netcdf dataset file not deleted. '

--- a/siphon/ncss.py
+++ b/siphon/ncss.py
@@ -344,12 +344,12 @@ try:
     @response_handlers.register('application/x-netcdf')
     @response_handlers.register('application/x-netcdf4')
     def read_netcdf(data, handle_units):  # pylint:disable=unused-argument
-        osType = platform.architecture()
-        if osType[1].lower() == 'windowspe':
+        ostype = platform.architecture()
+        if ostype[1].lower() == 'windowspe':
             with NamedTemporaryFile(delete=False) as tmp_file:
                 tmp_file.write(data)
                 tmp_file.flush()
-                atexit.register(deletetempfile,tmp_file.name)
+                atexit.register(deletetempfile, tmp_file.name)
                 return Dataset(tmp_file.name, 'r')
         else:
             with NamedTemporaryFile() as tmp_file:
@@ -362,10 +362,11 @@ except ImportError:
     warnings.warn('netCDF4 module not installed. '
                   'Will be unable to handle NetCDF returns from NCSS.')
 
+
 def deletetempfile(fname):
     try:
         remove(fname)
-    except PermissionError:
+    except OSError:
         import warnings
         warnings.warn('temporary netcdf dataset file not deleted. '
                       'to delete temporary dataset file in the future '


### PR DESCRIPTION
These changes were made in response to the inability of python to open a temporary file twice on Windows systems, Permission Denied error, thus preventing ncss.get_data() queries in Siphon. [Issue #24 NetCDF tempfile handling broken on windows](https://github.com/Unidata/siphon/issues/24).

The temporary file is now persistent but is then deleted at exit. The temporary file will only be removed if .close() method is called on the netCDF Dataset. With this fix the error message disappears and all nosetests pass. It has not been tested on Linux/Unix.

Siphon v0.3.1
Code that reproduces the error (also fails 2 nosetests; test_netcdf_point, test_netcdf4_point):
best_gfs = TDSCatalog('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/GFS/Global_0p5deg/catalog.xml?dataset=grib/NCEP/GFS/Global_0p5deg/Best')
best_gfs.datasets
best_ds = list(best_gfs.datasets.values())[0]
best_ds.access_urls
ncss = NCSS(best_ds.access_urls['NetcdfSubset'])
query = ncss.query()
query.lonlat_point(-110.9, 32.2).vertical_level(100000).time_range(start, end)
query.variables('Temperature_isobaric').accept('netcdf')
data = ncss.get_data(query)

...line 351, in read_netcdf
    return Dataset(tmp_file.name, 'r')
  File "netCDF4\_netCDF4.pyx", line 1616, in netCDF4._netCDF4.Dataset.__init__ (netCDF4\_netCDF4.c:9989)
RuntimeError: Permission denied
