### PR TITLE
Package updates

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=1.3
-ipython==3.2
-jsonschema
+nbconvert>=4.0
+# Until nbconvert 4.1
+IPython>=4.0

--- a/docs/source/notebook_gen_sphinxext.py
+++ b/docs/source/notebook_gen_sphinxext.py
@@ -5,7 +5,7 @@ import glob
 import os
 import os.path
 
-from IPython.nbconvert.exporters import rst
+from nbconvert.exporters import rst
 
 def setup(app):
     setup.app = app

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     extras_require={
         'netcdf': ['netCDF4>=1.1.0'],
         'dev': ['ipython[all]>=3.1'],
-        'doc': ['sphinx>=1.3', 'ipython[all]>=3.1'],
+        'doc': ['sphinx>=1.3', 'nbconvert>=4.0', 'IPython>=4.0'],
         'test': ['nose', 'netCDF4>=1.1.0',
                  'vcrpy~=1.5,!=1.7.0,!=1.7.1,!=1.7.2,!=1.7.3'],
         'examples': ['matplotlib>=1.3']

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ class MakeExamples(Command):
         import glob
         import os
         import os.path
-        from IPython.nbconvert.exporters import python
-        from IPython.config import Config
+        from nbconvert.exporters import python
+        from traitlets.config import Config
         examples_dir = os.path.join(os.path.dirname(__file__), 'examples')
         script_dir = os.path.join(examples_dir, 'scripts')
         if not os.path.exists(script_dir):


### PR DESCRIPTION
This improves documentation builds. Removing netCDF4 as a **requirement** should smooth the way to building on RTFD which is currently broken; we were conditionally importing it anyways, and only for NCSS support.

Moving to nbconvert gets closer to actually specifying what we need for our docs; unfortunately, it still (4.0) has an undocumented dependency on `IPython.core`. This should be resolved in 4.1 (see jupyter/nbconvert#122)