### PR TITLE
Http errors

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -52,6 +52,7 @@ class TDSCatalog(object):
 
         # get catalog.xml file
         resp = session.get(self.catalog_url)
+        resp.raise_for_status()
 
         # If we were given an HTML link, warn about it and try to fix to xml
         if 'html' in resp.headers['content-type']:
@@ -61,6 +62,7 @@ class TDSCatalog(object):
                                                                      new_url))
             self.catalog_url = new_url
             resp = session.get(self.catalog_url)
+            resp.raise_for_status()
 
         # begin parsing the xml doc
         root = ET.fromstring(resp.text)

--- a/siphon/tests/fixtures/radarserver_ds_denied
+++ b/siphon/tests/fixtures/radarserver_ds_denied
@@ -1,0 +1,17 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.3.1+20.gdd8f139.dirty)]
+    method: GET
+    uri: http://thredds-aws.unidata.ucar.edu/thredds/radarServer/nexrad/level2/S3/dataset.xml
+  response:
+    body: {string: ''}
+    headers:
+      Date: ['Thu, 29 Oct 2015 14:35:24 GMT']
+      Server: [Apache-Coyote/1.1]
+    status: {code: 403, message: Forbidden}
+version: 1

--- a/siphon/tests/fixtures/radarserver_toplevel_denied
+++ b/siphon/tests/fixtures/radarserver_toplevel_denied
@@ -1,0 +1,17 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.3.1+20.gdd8f139.dirty)]
+    method: GET
+    uri: http://thredds-aws.unidata.ucar.edu/thredds/radarServer/catalog.xml
+  response:
+    body: {string: ''}
+    headers:
+      Date: ['Thu, 29 Oct 2015 14:35:24 GMT']
+      Server: [Apache-Coyote/1.1]
+    status: {code: 403, message: Forbidden}
+version: 1

--- a/siphon/tests/test_radarsever.py
+++ b/siphon/tests/test_radarsever.py
@@ -5,6 +5,7 @@ from siphon.radarserver import (BadQueryError, RadarQuery, RadarServer,
                                 get_radarserver_datasets)
 
 from nose.tools import eq_, raises
+from requests import HTTPError
 
 recorder = siphon.testing.get_recorder(__file__)
 
@@ -120,3 +121,16 @@ class TestRadarServerDatasets(object):
         ds = get_radarserver_datasets('http://thredds.ucar.edu/thredds/')
         url = ds['NEXRAD Level III Radar from IDD'].follow().catalog_url
         assert RadarServer(url)
+
+
+class TestUnauthorizedErrors(object):
+    @recorder.use_cassette('radarserver_toplevel_denied')
+    @raises(HTTPError)
+    def test_get_rs_datasets_denied_throws(self):
+        get_radarserver_datasets('http://thredds-aws.unidata.ucar.edu/thredds/')
+
+    @raises(HTTPError)
+    @recorder.use_cassette('radarserver_ds_denied')
+    def test_rs_constructor_throws(self):
+        RadarServer('http://thredds-aws.unidata.ucar.edu/thredds/'
+                    'radarServer/nexrad/level2/S3/')


### PR DESCRIPTION
Make `requests` raise for http errors so that we get notified of problems right away. This fixes non-edu folks hitting the AWS TDS and getting strange Siphon errors rather than a clear message about not being allowed.