### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,68 +1,88 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
-
 sudo: false
 
 addons:
+  artifacts:
+    target_paths: /
+    paths:
+      - $(find $WHEELDIR -newer $WHEELDIR/download_marker -name *.whl | tr [:space:] :)
   apt:
-    packages:
-    - pandoc
+    packages: &base_build
     - libhdf5-serial-dev
     - libnetcdf-dev
 
+python:
+  - 3.5
+  - 2.7
+
+env:
+  global:
+    - WHEELHOUSE="https://unidata-python.s3.amazonaws.com/wheelhouse/index.html"
+    - WHEELDIR="wheelhouse/"
+  matrix:
+    - NOSE_WITH_COVERAGE=y NOSE_COVER_PACKAGE=siphon
+    - TASK="examples"
+    - TASK="lint"
+
 matrix:
   include:
-    - python: 3.5
-      env: NOSE_WITH_COVERAGE=y NOSE_COVER_PACKAGE=siphon
-    - python: 3.5
-      env: EXAMPLES=true
-    - python: 3.5
-      env: LINT=true
     - python: 2.7
-    - python: 2.7
-      env: EXAMPLES=true
-    - python: 2.7
-      env: DOCBUILD=true
-    - python: 2.7
-      env: LINT=true
+      env: TASK="docs"
+      addons:
+        apt:
+          packages:
+            - *base_build
+            - pandoc
     - python: 3.3
+      env:
     - python: 3.4
+      env:
+    - python: "3.5-dev"
+      env: PRE="--pre"
+    - python: nightly
+      env: PRE="--pre"
+  allow_failures:
+    - python: "3.5-dev"
+    - python: nightly
 
 before_install:
-  - if [[ $LINT == true ]]; then
+  - if [[ $TASK == "lint" ]]; then
       pip install flake8 pep8-naming;
     else
-      pip install -r requirements.txt;
-      if [[ $DOCBUILD == true || $EXAMPLES == true ]]; then
-        if [[ $EXAMPLES == true ]]; then
-          pip install -r examples/requirements.txt;
+      pip install --upgrade pip;
+      if [[ $TASK == "docs" || $TASK == "examples" ]]; then
+        if [[ $TASK == "examples" ]]; then
+          export VERSIONS="$VERSIONS -r examples/requirements.txt";
         fi;
         pip install -r docs/requirements.txt;
-      else
-        pip install "vcrpy>=1.7.4";
-        pip install nose;
-        if [[ $NOSE_WITH_COVERAGE == y ]]; then
-          pip install coverage;
-        fi;
       fi;
+      if [[ $NOSE_WITH_COVERAGE == y ]]; then
+        pip install coverage;
+      fi;
+      mkdir $WHEELDIR;
+      pip install ".[test]" -d $WHEELDIR -f $WHEELHOUSE $PRE $VERSIONS;
+      touch $WHEELDIR/download_marker;
+      travis_wait pip wheel ".[test]" -w $WHEELDIR -f $WHEELHOUSE $PRE $VERSIONS;
+      rm -f $WHEELDIR/MetPy*.whl;
     fi
 
 install:
-  - if [[ $LINT != true ]]; then
-      python setup.py install;
-    fi
-  - if [[ $EXAMPLES == true ]]; then
-      python setup.py examples;
+  - if [[ $TASK != "lint" ]]; then
+      pip install ".[test]" --upgrade --no-index -f file://$PWD/$WHEELDIR $VERSIONS;
+      if [[ $TASK == "examples" ]]; then
+        python setup.py examples;
+      fi;
     fi
 
 script:
-  - if [[ $LINT == true ]]; then
+  - if [[ $TASK == "lint" ]]; then
       flake8 siphon;
-    elif [[ $DOCBUILD == true ]]; then
+    elif [[ $TASK == "docs" ]]; then
       cd docs;
       make html;
-    elif [[ $EXAMPLES == true ]]; then
+    elif [[ $TASK == "examples" ]]; then
       cd examples;
       echo backend:agg > matplotlibrc;
       MPLBACKEND='agg' python test_examples.py;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-requests>=1.2
-numpy>=1.8.0
-protobuf>=3.0.0a3
-netCDF4>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,13 @@ setup(
                  'Operating System :: OS Independent',
                  'License :: OSI Approved :: MIT License'],
 
-    install_requires=['numpy>=1.8', 'protobuf>=3.0.0a3', 'requests>=1.2',
-                      'netCDF4>=1.1.0'],
+    install_requires=['numpy>=1.8', 'protobuf>=3.0.0a3', 'requests>=1.2'],
     extras_require={
+        'netcdf': ['netCDF4>=1.1.0'],
         'dev': ['ipython[all]>=3.1'],
         'doc': ['sphinx>=1.3', 'ipython[all]>=3.1'],
-        'test': ['nosetest', 'vcrpy~=1.5,!=1.7.0,!=1.7.1,!=1.7.2,!=1.7.3']
+        'test': ['nose', 'netCDF4>=1.1.0',
+                 'vcrpy~=1.5,!=1.7.0,!=1.7.1,!=1.7.2,!=1.7.3']
     },
 
     download_url='https://github.com/Unidata/siphon/archive/v%s.tar.gz' % ver,)


### PR DESCRIPTION
Rework travis config:
- Build wheels for new versions as needed and get/store in S3.
- Refactor build matrix to be a bit cleaner
- Only install pandoc for doc build
- Use the 'test' extra defined in setup.py to get dependencies.
- Add builds against Travis' nightly and 3.5-dev Python development builds, with pre-release packages