### PR TITLE
Replace nosetests with py.test

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = siphon/_version.py,siphon/cdmr/ncStream_pb2.py
+omit = siphon/_version.py,siphon/cdmr/ncStream_pb2.py,*/tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Thumbs.db
 # Packages
 *.egg
 *.egg-info
+.eggs/
 MANIFEST
 dist
 build
@@ -46,6 +47,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.cache
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - WHEELDIR="wheelhouse/"
     - EXTRAS="test"
   matrix:
-    - NOSE_WITH_COVERAGE=y NOSE_COVER_PACKAGE=siphon
+    - TASK="coverage"
     - TASK="examples"
     - TASK="lint"
 
@@ -59,9 +59,8 @@ before_install:
           export EXTRAS="$EXTRAS,examples";
         fi;
         pip install -r docs/requirements.txt;
-      fi;
-      if [[ $NOSE_WITH_COVERAGE == y ]]; then
-        pip install coverage;
+      elif [[ $TASK == "coverage" ]]; then
+        pip install pytest-cov;
       fi;
       mkdir $WHEELDIR;
       pip install ".[$EXTRAS]" -d $WHEELDIR -f $WHEELHOUSE $PRE $VERSIONS;
@@ -88,12 +87,14 @@ script:
       cd examples;
       echo backend:agg > matplotlibrc;
       MPLBACKEND='agg' python test_examples.py;
+    elif [[ $TASK == "coverage" ]]; then
+      python setup.py test --addopts --cov=siphon;
     else
-      nosetests;
+      python setup.py test;
     fi
 
 after_success:
-  - if [[ $NOSE_WITH_COVERAGE == y ]]; then
+  - if [[ $TASK == "coverage" ]]; then
       pip install codecov codacy-coverage;
       codecov;
       coverage xml;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,14 @@ Install siphon:
 
     python setup.py install
 
-Install nose and make sure the tests pass:
+Install pytest and make sure the tests pass:
 
-    pip install nose
-    nosetests
+    pip install pytest
+    py.test
 
 Make your change. Add tests for your change. Make the tests pass:
 
-    nosetests
+    py.test
 
 Push to your fork and [submit a pull request][pr].
 

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,6 @@ Dependencies
 Developer Dependencies
 ----------------------
 
-- nose
+- pytest
 - vcrpy
 - flake8

--- a/docs/source/developerguide.rst
+++ b/docs/source/developerguide.rst
@@ -6,7 +6,7 @@ Developer's Guide
 Requirements
 ------------
 
-- nose
+- pytest
 - flake8
 - sphinx >= 1.3
 - sphinx-rtd-theme >= 0.1.7
@@ -74,7 +74,7 @@ Testing
 -------
 
 Unit tests are the lifeblood of the project, as it ensures that we can continue to add and change the code
-and stay confident that things have not broken. Running the tests requires ``nose``, which is easily available
+and stay confident that things have not broken. Running the tests requires ``pytest``, which is easily available
 through ``conda`` or ``pip``. Running the tests can be done via either:
 
 .. parsed-literal::
@@ -83,14 +83,14 @@ through ``conda`` or ``pip``. Running the tests can be done via either:
 or
 
 .. parsed-literal::
-    nosetests
+    py.test
 
-Using ``nosetests`` also gives you the option of passing a path to the directory with tests to run, which can speed
+Using ``py.test`` also gives you the option of passing a path to the directory with tests to run, which can speed
 running only the tests of interest when doing development. For instance, to only run the tests in the ``siphon/cdmr``
 directory, use:
 
 .. parsed-literal::
-    nosetests siphon/cdmr
+    py.test siphon/cdmr
 
 ----------
 Code Style

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - netcdf4
   - ipython-notebook
   - sphinx
-  - nose
+  - pytest
   - vcrpy
   - flake8
   - pep8-naming

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = examples docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,6 @@ versionfile_source = siphon/_version.py
 versionfile_build = siphon/_version.py
 tag_prefix = v
 parentdir_prefix = siphon-
+
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
     author_email = 'support-python@unidata.ucar.edu',
     license = 'MIT',
     url = "https://github.com/Unidata/siphon",
-    test_suite = "nose.collector",
     description = ("A collection of Python utilities for interacting with the "
                                    "Unidata technology stack."),
     keywords='meteorology weather',
@@ -68,7 +67,7 @@ setup(
     extras_require={
         'netcdf': 'netCDF4>=1.1.0',
         'dev': 'ipython[all]>=3.1',
-        'test': ['nose', 'netCDF4>=1.1.0',
+        'test': ['pytest', 'pytest-runner', 'netCDF4>=1.1.0',
                  'vcrpy~=1.5,!=1.7.0,!=1.7.1,!=1.7.2,!=1.7.3'],
         'doc': ['sphinx>=1.3', 'nbconvert>=4.0', 'IPython>=4.0'],
         'examples': 'matplotlib>=1.3'

--- a/siphon/cdmr/tests/test_dataset.py
+++ b/siphon/cdmr/tests/test_dataset.py
@@ -4,7 +4,7 @@
 
 from siphon.testing import get_recorder
 from siphon.cdmr import Dataset
-from nose.tools import eq_, assert_almost_equals
+from numpy.testing import assert_almost_equal
 
 recorder = get_recorder(__file__)
 
@@ -40,29 +40,28 @@ def test_compression():
     ds = Dataset(get_fixed_url())
     var = ds.variables['Temperature_isobaric']
     subset = var[0, 0]
-    eq_(subset.shape, var.shape[2:])
-    assert_almost_equals(subset[0, 0], 206.65640259, 6)
+    assert subset.shape == var.shape[2:]
+    assert_almost_equal(subset[0, 0], 206.65640259, 6)
 
 
 @recorder.use_cassette('nc4_enum')
 def test_enum():
     ds = Dataset('http://localhost:8080/thredds/cdmremote/nc4/tst/test_enum_type.nc')
     var = ds.variables['primary_cloud'][:]
-    eq_(var[0], 0)
-    eq_(var[1], 2)
-    eq_(var[2], 0)
-    eq_(var[3], 1)
-    eq_(var[4], 255)
+    assert var[0] == 0
+    assert var[1] == 2
+    assert var[2] == 0
+    assert var[3] == 1
+    assert var[4] == 255
 
 
 @recorder.use_cassette('nc4_opaque')
 def test_opaque():
     ds = Dataset('http://localhost:8080/thredds/cdmremote/nc4/tst/tst_opaques.nc')
     var = ds.variables['var'][:]
-    eq_(var.shape, (3,))
-    eq_(var[0],
-        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
+    assert var.shape == (3,)
+    assert var[0] == (b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                      b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 
 
 class TestIndexing(object):
@@ -76,46 +75,45 @@ class TestIndexing(object):
     @recorder.use_cassette('rap_ncstream_slices')
     def test_slices(self):
         subset = self.var[1:2, 1:3, 4:7, 8:12]
-        eq_(subset.shape, (1, 2, 3, 4))
+        assert subset.shape, (1, 2, 3 == 4)
 
     @recorder.use_cassette('rap_ncstream_first_index')
     def test_first_index(self):
         subset = self.var[5, 10]
-        eq_(subset.shape, self.var.shape[2:])
+        assert subset.shape == self.var.shape[2:]
 
     @recorder.use_cassette('rap_ncstream_ellipsis_middle')
     def test_ellipsis_middle(self):
         subset = self.var[2, ..., 3]
-        eq_(subset.shape, self.var.shape[1:-1])
+        assert subset.shape == self.var.shape[1:-1]
 
     @recorder.use_cassette('rap_ncstream_last_index')
     def test_last_index(self):
         subset = self.var[..., 2]
-        eq_(subset.shape, self.var.shape[:-1])
+        assert subset.shape == self.var.shape[:-1]
 
     @recorder.use_cassette('rap_ncstream_negative_index')
     def test_negative_index(self):
         subset = self.var[0, -1]
-        eq_(subset.shape, self.var.shape[2:])
+        assert subset.shape == self.var.shape[2:]
 
     @recorder.use_cassette('rap_ncstream_negative_slice')
     def test_negative_slice(self):
         subset = self.var[1:-1, 1, 2]
-        eq_(subset.shape[1:], self.var.shape[3:])
-        eq_(subset.shape[0], self.var.shape[0] - 2)
+        assert subset.shape[1:] == self.var.shape[3:]
+        assert subset.shape[0] == self.var.shape[0] - 2
 
     @recorder.use_cassette('rap_ncstream_all_indices')
     def test_all_indices(self):
         subset = self.var[0, -1, 2, 3]
-        eq_(subset.shape, ())
+        assert subset.shape == ()
 
     @recorder.use_cassette('rap_ncstream_slice_to_end')
     def test_slice_to_end(self):
         subset = self.var[0, 0, :3, :]
-        eq_(subset.shape, (3, self.var.shape[-1]))
+        assert subset.shape, (3 == self.var.shape[-1])
 
     @recorder.use_cassette('rap_ncstream_decimation')
     def test_decimation(self):
         subset = self.var[0, 0, ::2, ::2]
-        eq_(subset.shape, ((self.var.shape[-2] + 1)//2,
-                           (self.var.shape[-1] + 1)//2))
+        assert subset.shape, ((self.var.shape[-2] + 1)//2 == (self.var.shape[-1] + 1)//2)

--- a/siphon/cdmr/tests/test_ncstream.py
+++ b/siphon/cdmr/tests/test_ncstream.py
@@ -7,8 +7,6 @@ from siphon.testing import get_recorder
 from siphon.cdmr.ncstream import read_ncstream_messages, read_var_int
 from siphon.cdmr.ncStream_pb2 import Header
 
-from nose.tools import eq_
-
 HEAD_LOCATION_DEFAULT = ''
 HEAD_TITLE_DEFAULT = ''
 HEAD_ID_DEFAULT = ''
@@ -40,13 +38,13 @@ def test_var_int():
 
 
 def check_var_int(src, result):
-    eq_(read_var_int(BytesIO(src)), result)
+    read_var_int(BytesIO(src)) == result
 
 
 def test_header_message_def():
     f = get_header_remote()
     messages = read_ncstream_messages(f)
-    eq_(len(messages), 1)
+    assert len(messages) == 1
     assert isinstance(messages[0], Header)
     head = messages[0]
     # test that the header message definition has not changed!
@@ -63,7 +61,7 @@ def test_header_message_def():
 def test_remote_header():
     f = get_header_remote()
     messages = read_ncstream_messages(f)
-    eq_(len(messages), 1)
+    assert len(messages) == 1
     assert isinstance(messages[0], Header)
 
     head = messages[0]
@@ -80,5 +78,5 @@ def test_local_data():
     f = BytesIO(b'\xab\xec\xce\xba\x17\n\x0breftime_ISO\x10\x07\x1a\x04\n'
                 b'\x02\x10\x01(\x02\x01\x142014-10-28T21:00:00Z')
     messages = read_ncstream_messages(f)
-    eq_(len(messages), 1)
-    eq_(messages[0][0], b'2014-10-28T21:00:00Z')
+    assert len(messages) == 1
+    assert messages[0][0] == b'2014-10-28T21:00:00Z'

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -59,14 +59,14 @@ class TestCatalog(object):
         assert cat
 
     @recorder.use_cassette('radar_dataset_cat')
-    def simple_test_radar_cat(self):
+    def test_simple_radar_cat(self):
         url = 'http://thredds.ucar.edu/thredds/radarServer/nexrad/level2/' \
               'IDD/dataset.xml'
         cat = TDSCatalog(url)
         assert cat
 
     @recorder.use_cassette('point_feature_dataset_xml')
-    def simple_test_point_feature_collection_xml(self):
+    def test_simple_point_feature_collection_xml(self):
         url = 'http://thredds.ucar.edu/thredds/catalog/nws/metar/' \
               'ncdecoded/catalog.xml?dataset=nws/metar/ncdecoded' \
               '/Metar_Station_Data_fc.cdmr'

--- a/siphon/tests/test_http_util.py
+++ b/siphon/tests/test_http_util.py
@@ -3,12 +3,11 @@
 # SPDX-License-Identifier: MIT
 
 from datetime import datetime, timedelta
+import pytest
 
 import siphon.testing
 from siphon.http_util import (DataQuery, HTTPEndPoint, HTTPError, create_http_session,
                               parse_iso_date, urlopen, utc)
-
-from nose.tools import eq_, raises
 
 recorder = siphon.testing.get_recorder(__file__)
 
@@ -16,7 +15,7 @@ recorder = siphon.testing.get_recorder(__file__)
 @recorder.use_cassette('top_thredds_catalog')
 def test_urlopen():
     fobj = urlopen('http://thredds-test.unidata.ucar.edu/thredds/catalog.xml')
-    eq_(fobj.read(2), b'<?')
+    assert fobj.read(2) == b'<?'
 
 
 @recorder.use_cassette('top_thredds_catalog')
@@ -28,90 +27,99 @@ def test_session():
 
 def test_parse_iso():
     parsed = parse_iso_date('2015-06-15T12:00:00Z')
-    eq_(parsed.utcoffset(), timedelta(0))
-    eq_(parsed, datetime(2015, 6, 15, 12, tzinfo=utc))
+    assert parsed.utcoffset() == timedelta(0)
+    assert parsed == datetime(2015, 6, 15, 12, tzinfo=utc)
 
 
-class TestDataQuery(object):
-    def test_basic(self):
-        dr = DataQuery()
-        dr.all_times()
-        dr.variables('foo', 'bar')
-        query = repr(dr)  # To check repr for once
-        assert 'temporal=all' in query
-        assert 'var=foo' in query
-        assert 'var=bar' in query
+def test_data_query_basic():
+    dr = DataQuery()
+    dr.all_times()
+    dr.variables('foo', 'bar')
+    query = repr(dr)  # To check repr for once
+    assert 'temporal=all' in query
+    assert 'var=foo' in query
+    assert 'var=bar' in query
 
-    def test_repeated_vars(self):
-        dr = DataQuery()
-        dr.variables('foo', 'bar')
-        dr.variables('foo')
-        query = str(dr)
-        eq_(query.count('foo'), 1)
-        eq_(query.count('bar'), 1)
 
-    def test_time_reset(self):
-        dr = DataQuery().all_times().time(datetime.utcnow())
-        query = str(dr)
-        assert query.startswith('time='), 'Bad string: ' + query
-        eq_(query.count('='), 1)
+def test_data_query_repeated_vars():
+    dr = DataQuery()
+    dr.variables('foo', 'bar')
+    dr.variables('foo')
+    query = str(dr)
+    assert query.count('foo') == 1
+    assert query.count('bar') == 1
 
-    def test_time_reset2(self):
-        dr = DataQuery().time(datetime.utcnow()).all_times()
-        eq_(str(dr), 'temporal=all')
 
-    def test_time_reset3(self):
-        dt = datetime(2015, 6, 12, 12, 0, 0)
-        dt2 = datetime(2015, 6, 13, 12, 0, 0)
-        dr = DataQuery().all_times().time_range(dt, dt2)
-        query = str(dr)
-        assert 'time_start=2015-06-12T12' in query, 'Bad string: ' + query
-        assert 'time_end=2015-06-13T12' in query, 'Bad string: ' + query
-        eq_(query.count('='), 2)
+def test_data_query_time_reset():
+    dr = DataQuery().all_times().time(datetime.utcnow())
+    query = str(dr)
+    assert query.startswith('time='), 'Bad string: ' + query
+    assert query.count('=') == 1
 
-    def test_time_format(self):
-        dt = datetime(2015, 6, 15, 12, 0, 0)
-        dr = DataQuery().time(dt)
-        query = str(dr)
-        eq_(query, 'time=2015-06-15T12%3A00%3A00')
 
-    def test_spatial_reset(self):
-        dr = DataQuery().lonlat_box(1, 2, 3, 4).lonlat_point(-1, -2)
-        query = str(dr)
-        assert 'latitude=-2' in query
-        assert 'longitude=-1' in query
-        eq_(query.count('='), 2)
+def test_data_query_time_reset2():
+    dr = DataQuery().time(datetime.utcnow()).all_times()
+    assert str(dr) == 'temporal=all'
 
-    def test_spatial_reset2(self):
-        dr = DataQuery().lonlat_point(-1, -2).lonlat_box(1, 2, 3, 4)
-        query = str(dr)
-        assert 'south=3' in query
-        assert 'north=4' in query
-        assert 'west=1' in query
-        assert 'east=2' in query
-        eq_(query.count('='), 4)
 
-    def test_iter(self):
-        dt = datetime.utcnow()
-        dr = DataQuery().time(dt).lonlat_point(-1, -2)
-        d = dict(dr)
+def test_data_query_time_reset3():
+    dt = datetime(2015, 6, 12, 12, 0, 0)
+    dt2 = datetime(2015, 6, 13, 12, 0, 0)
+    dr = DataQuery().all_times().time_range(dt, dt2)
+    query = str(dr)
+    assert 'time_start=2015-06-12T12' in query, 'Bad string: ' + query
+    assert 'time_end=2015-06-13T12' in query, 'Bad string: ' + query
+    assert query.count('=') == 2
 
-        eq_(d['time'], dt.isoformat())
-        eq_(d['latitude'], -2)
-        eq_(d['longitude'], -1)
 
-    def test_items(self):
-        dt = datetime.utcnow()
-        dr = DataQuery().time(dt).lonlat_point(-1, -2)
-        l = list(dr.items())
+def test_data_query_time_format():
+    dt = datetime(2015, 6, 15, 12, 0, 0)
+    dr = DataQuery().time(dt)
+    query = str(dr)
+    assert query == 'time=2015-06-15T12%3A00%3A00'
 
-        assert ('time', dt.isoformat()) in l
-        assert ('latitude', -2) in l
-        assert ('longitude', -1) in l
 
-    def test_add(self):
-        dr = DataQuery().add_query_parameter(foo='bar')
-        eq_(str(dr), 'foo=bar')
+def test_data_query_spatial_reset():
+    dr = DataQuery().lonlat_box(1, 2, 3, 4).lonlat_point(-1, -2)
+    query = str(dr)
+    assert 'latitude=-2' in query
+    assert 'longitude=-1' in query
+    assert query.count('=') == 2
+
+
+def test_data_query_spatial_reset2():
+    dr = DataQuery().lonlat_point(-1, -2).lonlat_box(1, 2, 3, 4)
+    query = str(dr)
+    assert 'south=3' in query
+    assert 'north=4' in query
+    assert 'west=1' in query
+    assert 'east=2' in query
+    assert query.count('=') == 4
+
+
+def test_data_query_iter():
+    dt = datetime.utcnow()
+    dr = DataQuery().time(dt).lonlat_point(-1, -2)
+    d = dict(dr)
+
+    assert d['time'] == dt.isoformat()
+    assert d['latitude'] == -2
+    assert d['longitude'] == -1
+
+
+def test_data_query_items():
+    dt = datetime.utcnow()
+    dr = DataQuery().time(dt).lonlat_point(-1, -2)
+    l = list(dr.items())
+
+    assert ('time', dt.isoformat()) in l
+    assert ('latitude', -2) in l
+    assert ('longitude', -1) in l
+
+
+def test_data_query_add():
+    dr = DataQuery().add_query_parameter(foo='bar')
+    assert str(dr) == 'foo=bar'
 
 
 class TestEndPoint(object):
@@ -141,10 +149,10 @@ class TestEndPoint(object):
         assert resp.content
 
     @recorder.use_cassette('gfs-metadata-map-bad')
-    @raises(HTTPError)
     def test_get_error(self):
-        self.endpoint.get_path('')
+        with pytest.raises(HTTPError):
+            self.endpoint.get_path('')
 
     def test_url_path(self):
         path = self.endpoint.url_path('foobar.html')
-        eq_(path, self.server + self.api + '/foobar.html')
+        assert path == self.server + self.api + '/foobar.html'

--- a/siphon/tests/test_metadata.py
+++ b/siphon/tests/test_metadata.py
@@ -5,7 +5,6 @@
 import logging
 import xml.etree.ElementTree as ET
 
-from nose.tools import assert_dict_equal, assert_equal
 from siphon.metadata import TDSCatalogMetadata, _SimpleTypes, _ComplexTypes
 
 log = logging.getLogger("siphon.metadata")
@@ -70,7 +69,7 @@ class TestSimpleTypes(object):
         element = ET.fromstring(xml)
         assert element.attrib
         val = self.st.handle_upOrDown(element)
-        assert_dict_equal(val, expected)
+        assert val == expected
 
     def test_data_format_type(self):
         xml = '<dataFormat>NcML</dataFormat>'
@@ -79,7 +78,7 @@ class TestSimpleTypes(object):
         assert not element.attrib
         assert element.text
         val = self.st.handle_dataFormat(element)
-        assert_dict_equal(expected, val)
+        assert expected == val
 
     def test_data_type(self):
         xml = '<dataType>GRID</dataType>'
@@ -89,7 +88,7 @@ class TestSimpleTypes(object):
         assert not element.attrib
         assert element.text
         val = self.st.handle_dataType(element)
-        assert_dict_equal(expected, val)
+        assert expected == val
 
 
 class TestComplexTypes(object):
@@ -110,7 +109,7 @@ class TestComplexTypes(object):
         for child in element:
             actual.update(self.st.handle_spatialRange(element))
 
-        assert_dict_equal(actual, expected)
+        assert actual == expected
 
     def test_controlled_vocabulary(self):
         xml = '<name vocabulary="MyVocabName">' \
@@ -119,7 +118,7 @@ class TestComplexTypes(object):
                     "name": "NOAA and NCEP"}
         element = ET.fromstring(xml)
         actual = self.st.handle_controlledVocabulary(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_date_type_formatted(self):
         xml = '<start format="yyyy DDD" type="created">1999 189</start>'
@@ -128,7 +127,7 @@ class TestComplexTypes(object):
                     "value": "1999 189"}
         element = ET.fromstring(xml)
         actual = self.st.handle_dateTypeFormatted(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_source_type(self):
         xml = '<publisher><name vocabulary="DIF">UCAR/NCAR/CDP</name>' \
@@ -141,7 +140,7 @@ class TestComplexTypes(object):
                     "email": "cdp@ucar.edu",
                     "url": "http://dataportal.ucar.edu"}
         actual = self.st.handle_sourceType(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_time_coverage_type1(self):
         xml = '<timeCoverage><end>present</end><duration>10 days</duration>' \
@@ -151,7 +150,7 @@ class TestComplexTypes(object):
                     "duration": "10 days",
                     "resolution": "15 minutes"}
         actual = self.st.handle_timeCoverageType(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_time_coverage_type2(self):
         xml = '<timeCoverage><start>1999-11-16T12:00:00</start>' \
@@ -160,7 +159,7 @@ class TestComplexTypes(object):
         expected = {"end": "present",
                     "start": "1999-11-16T12:00:00"}
         actual = self.st.handle_timeCoverageType(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_time_coverage_type3(self):
         xml = '<timeCoverage><start>1999-11-16T12:00:00</start>' \
@@ -169,7 +168,7 @@ class TestComplexTypes(object):
         expected = {"duration": "P3M",
                     "start": "1999-11-16T12:00:00"}
         actual = self.st.handle_timeCoverageType(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_variable(self):
         xml = '<variable name="wdir" vocabulary_name="Wind Direction" ' \
@@ -180,14 +179,14 @@ class TestComplexTypes(object):
                     "units": "degrees",
                     "description": "Wind Direction @ surface"}
         actual = self.st.handle_variable(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_variable2(self):
         xml = '<variable name="wdir"></variable>'
         element = ET.fromstring(xml)
         expected = {"name": "wdir"}
         actual = self.st.handle_variable(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_variable3(self):
         xml = '<variable name="wdir">Wind Direction @ surface</variable>'
@@ -195,7 +194,7 @@ class TestComplexTypes(object):
         expected = {"name": "wdir",
                     "description": "Wind Direction @ surface"}
         actual = self.st.handle_variable(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_variable_map(self):
         xml = '<variableMap xmlns:xlink="http://www.w3.org/1999/xlink" ' \
@@ -204,7 +203,7 @@ class TestComplexTypes(object):
         expected = {
             "{http://www.w3.org/1999/xlink}href": "../standardQ/Eta.xml"}
         actual = self.st.handle_variableMap(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_variable_map2(self):
         xml = '<variableMap xmlns:xlink="http://www.w3.org/1999/xlink" ' \
@@ -215,7 +214,7 @@ class TestComplexTypes(object):
                     "{http://www.w3.org/1999/xlink}title":
                         "variables"}
         actual = self.st.handle_variableMap(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_variables(self):
         xml = '<variables vocabulary="CF-1.0">' \
@@ -442,8 +441,8 @@ class TestMetadata(object):
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "authority" in md
-        assert_equal(len(md["authority"]), 1)
-        assert_equal(md["authority"][0], "edu.ucar.unidata")
+        assert len(md["authority"]) == 1
+        assert md["authority"][0] == "edu.ucar.unidata"
 
     def test_publisher(self):
         xml = '<publisher><name vocabulary="DIF">UCAR/UNIDATA</name>' \
@@ -453,11 +452,11 @@ class TestMetadata(object):
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "publisher" in md
-        assert_equal(len(md["publisher"]), 1)
-        assert_equal(md["publisher"][0]["vocabulary"], "DIF")
-        assert_equal(md["publisher"][0]["name"], "UCAR/UNIDATA")
-        assert_equal(md["publisher"][0]["url"], "http://www.unidata.ucar.edu/")
-        assert_equal(md["publisher"][0]["email"], "support@unidata.ucar.edu")
+        assert len(md["publisher"]) == 1
+        assert md["publisher"][0]["vocabulary"] == "DIF"
+        assert md["publisher"][0]["name"] == "UCAR/UNIDATA"
+        assert md["publisher"][0]["url"] == "http://www.unidata.ucar.edu/"
+        assert md["publisher"][0]["email"] == "support@unidata.ucar.edu"
 
     def test_creator(self):
         xml = '<creator><name vocabulary="DIF">DOC/NOAA/NWS/NCEP</name>' \
@@ -467,20 +466,19 @@ class TestMetadata(object):
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "creator" in md
-        assert_equal(len(md["creator"]), 1)
-        assert_equal(md["creator"][0]["vocabulary"], "DIF")
-        assert_equal(md["creator"][0]["name"], "DOC/NOAA/NWS/NCEP")
-        assert_equal(md["creator"][0]["url"], "http://www.ncep.noaa.gov/")
-        assert_equal(md["creator"][0]["email"],
-                     "http://www.ncep.noaa.gov/mail_liaison.shtml")
+        assert len(md["creator"]) == 1
+        assert md["creator"][0]["vocabulary"] == "DIF"
+        assert md["creator"][0]["name"] == "DOC/NOAA/NWS/NCEP"
+        assert md["creator"][0]["url"] == "http://www.ncep.noaa.gov/"
+        assert md["creator"][0]["email"] == "http://www.ncep.noaa.gov/mail_liaison.shtml"
 
     def test_keyword(self):
         xml = "<keyword>Ocean Biomass</keyword>"
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "keyword" in md
-        assert_equal(len(md["keyword"]), 1)
-        assert_equal(md["keyword"][0]["name"], "Ocean Biomass")
+        assert len(md["keyword"]) == 1
+        assert md["keyword"][0]["name"] == "Ocean Biomass"
 
     def test_project(self):
         xml = '<project vocabulary="DIF">NASA Earth Science Project Office, ' \
@@ -488,33 +486,33 @@ class TestMetadata(object):
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "project" in md
-        assert_equal(len(md["project"]), 1)
-        assert_equal(md["project"][0]["vocabulary"], "DIF")
-        assert_equal(md["project"][0]["name"],
-                     "NASA Earth Science Project Office, Ames Research Center")
+        assert len(md["project"]) == 1
+        assert md["project"][0]["vocabulary"] == "DIF"
+        assert md["project"][0]["name"] == "NASA Earth Science Project Office, " \
+                                           "Ames Research Center"
 
     def test_data_format(self):
         xml = '<dataFormat>GRIB-1</dataFormat>'
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "dataFormat" in md
-        assert_equal(md["dataFormat"], "GRIB-1")
+        assert md["dataFormat"] == "GRIB-1"
 
     def test_data_type(self):
         xml = '<dataType>GRID</dataType>'
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "dataType" in md
-        assert_equal(md["dataType"], "GRID")
+        assert md["dataType"] == "GRID"
 
     def test_date(self):
         xml = '<date type="modified">2015-06-11T02:09:52Z</date>'
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "date" in md
-        assert_equal(len(md["date"]), 1)
-        assert_equal(md["date"][0]["type"], "modified")
-        assert_equal(md["date"][0]["value"], "2015-06-11T02:09:52Z")
+        assert len(md["date"]) == 1
+        assert md["date"][0]["type"] == "modified"
+        assert md["date"][0]["value"] == "2015-06-11T02:09:52Z"
 
     def test_time_coverage(self):
         xml = '<timeCoverage><end>present</end><duration>45 days</duration>' \
@@ -522,6 +520,6 @@ class TestMetadata(object):
         element = self._make_element(xml)
         md = TDSCatalogMetadata(element).metadata
         assert "timeCoverage" in md
-        assert_equal(len(md["timeCoverage"]), 1)
-        assert_equal(md["timeCoverage"][0]["end"], "present")
-        assert_equal(md["timeCoverage"][0]["duration"], "45 days")
+        assert len(md["timeCoverage"]) == 1
+        assert md["timeCoverage"][0]["end"] == "present"
+        assert md["timeCoverage"][0]["duration"] == "45 days"

--- a/siphon/tests/test_ncss.py
+++ b/siphon/tests/test_ncss.py
@@ -10,38 +10,39 @@ import numpy as np
 import siphon.testing
 from siphon.ncss import NCSS, NCSSQuery, ResponseRegistry
 
-from nose.tools import eq_
-
 recorder = siphon.testing.get_recorder(__file__)
 
 
-class TestNCSSQuery(object):
-    def test_proj_box(self):
-        nq = NCSSQuery().lonlat_point(1, 2).projection_box(-1, -2, -3, -4)
-        query = str(nq)
-        eq_(query.count('='), 4)
-        assert 'minx=-1' in query
-        assert 'maxx=-3' in query
-        assert 'miny=-2' in query
-        assert 'maxy=-4' in query
+def test_ncss_query_proj_box():
+    nq = NCSSQuery().lonlat_point(1, 2).projection_box(-1, -2, -3, -4)
+    query = str(nq)
+    assert query.count('=') == 4
+    assert 'minx=-1' in query
+    assert 'maxx=-3' in query
+    assert 'miny=-2' in query
+    assert 'maxy=-4' in query
 
-    def test_vertical_level(self):
-        nq = NCSSQuery().vertical_level(50000)
-        eq_(str(nq), 'vertCoord=50000')
 
-    def test_add_latlon(self):
-        nq = NCSSQuery().add_lonlat(True)
-        eq_(str(nq), 'addLatLon=True')
+def test_ncss_query_vertical_level():
+    nq = NCSSQuery().vertical_level(50000)
+    assert str(nq) == 'vertCoord=50000'
 
-    def test_strides(self):
-        nq = NCSSQuery().strides(5, 10)
-        query = str(nq)
-        assert 'timeStride=5' in query
-        assert 'horizStride=10' in query
 
-    def test_accept(self):
-        nq = NCSSQuery().accept('csv')
-        eq_(str(nq), 'accept=csv')
+def test_ncss_query_add_latlon():
+    nq = NCSSQuery().add_lonlat(True)
+    assert str(nq) == 'addLatLon=True'
+
+
+def test_ncss_query_strides():
+    nq = NCSSQuery().strides(5, 10)
+    query = str(nq)
+    assert 'timeStride=5' in query
+    assert 'horizStride=10' in query
+
+
+def test_ncss_query_accept():
+    nq = NCSSQuery().accept('csv')
+    assert str(nq) == 'accept=csv'
 
 
 # This allows us to override the response handler registry, so we can test that we
@@ -88,8 +89,8 @@ class TestNCSS(object):
 
         assert 'Temperature_isobaric' in xml_data
         assert 'Relative_humidity_isobaric' in xml_data
-        eq_(xml_data['lat'][0], 40)
-        eq_(xml_data['lon'][0], -105)
+        assert xml_data['lat'][0] == 40
+        assert xml_data['lon'][0] == -105
 
     @recorder.use_cassette('ncss_gfs_csv_point')
     def test_csv_point(self):
@@ -98,8 +99,8 @@ class TestNCSS(object):
 
         assert 'Temperature_isobaric' in csv_data
         assert 'Relative_humidity_isobaric' in csv_data
-        eq_(csv_data['lat'][0], 40)
-        eq_(csv_data['lon'][0], -105)
+        assert csv_data['lat'][0] == 40
+        assert csv_data['lon'][0] == -105
 
     @recorder.use_cassette('ncss_gfs_csv_point')
     def test_unit_handler_csv(self):
@@ -108,12 +109,12 @@ class TestNCSS(object):
         csv_data = self.ncss.get_data(self.nq)
 
         temp = csv_data['Temperature_isobaric']
-        eq_(len(temp), 2)
-        eq_(temp[1], 'K')
+        assert len(temp) == 2
+        assert temp[1] == 'K'
 
         relh = csv_data['Relative_humidity_isobaric']
-        eq_(len(relh), 2)
-        eq_(relh[1], '%')
+        assert len(relh) == 2
+        assert relh[1] == '%'
 
     @recorder.use_cassette('ncss_gfs_xml_point')
     def test_unit_handler_xml(self):
@@ -122,12 +123,12 @@ class TestNCSS(object):
         xml_data = self.ncss.get_data(self.nq)
 
         temp = xml_data['Temperature_isobaric']
-        eq_(len(temp), 2)
-        eq_(temp[1], 'K')
+        assert len(temp) == 2
+        assert temp[1] == 'K'
 
         relh = xml_data['Relative_humidity_isobaric']
-        eq_(len(relh), 2)
-        eq_(relh[1], '%')
+        assert len(relh) == 2
+        assert relh[1] == '%'
 
     @recorder.use_cassette('ncss_gfs_netcdf_point')
     def test_netcdf_point(self):
@@ -136,8 +137,8 @@ class TestNCSS(object):
 
         assert 'Temperature_isobaric' in nc.variables
         assert 'Relative_humidity_isobaric' in nc.variables
-        eq_(nc.variables['latitude'][0], 40)
-        eq_(nc.variables['longitude'][0], -105)
+        assert nc.variables['latitude'][0] == 40
+        assert nc.variables['longitude'][0] == -105
 
     @recorder.use_cassette('ncss_gfs_netcdf4_point')
     def test_netcdf4_point(self):
@@ -146,15 +147,15 @@ class TestNCSS(object):
 
         assert 'Temperature_isobaric' in nc.variables
         assert 'Relative_humidity_isobaric' in nc.variables
-        eq_(nc.variables['latitude'][0], 40)
-        eq_(nc.variables['longitude'][0], -105)
+        assert nc.variables['latitude'][0] == 40
+        assert nc.variables['longitude'][0] == -105
 
     @recorder.use_cassette('ncss_gfs_vertical_level')
     def test_vertical_level(self):
         self.nq.accept('csv').vertical_level(50000)
         csv_data = self.ncss.get_data(self.nq)
 
-        eq_(str(csv_data['Temperature_isobaric'])[:6], '263.39')
+        assert str(csv_data['Temperature_isobaric'])[:6] == '263.39'
 
     @recorder.use_cassette('ncss_gfs_csv_point')
     def test_raw_csv(self):

--- a/siphon/tests/test_ncss_dataset.py
+++ b/siphon/tests/test_ncss_dataset.py
@@ -5,7 +5,6 @@
 import logging
 import xml.etree.ElementTree as ET
 
-from nose.tools import assert_dict_equal, assert_equal
 from siphon.ncss_dataset import NCSSDataset, _Types
 from siphon.testing import get_recorder
 from siphon.http_util import urlopen
@@ -41,72 +40,81 @@ recorder = get_recorder(__file__)
 
 
 class TestSimpleTypes(object):
-
+    'Test parsing simple types from NCSS dataset.xml'
     @classmethod
     def setup_class(cls):
         cls.types = _Types()
 
     def test_attribute_1(self):
+        'Test parsing a string attribute'
         xml = '<attribute name="long_name" ' \
               'value="Specified height level above ground"/>'
         element = ET.fromstring(xml)
         expected = {"long_name": "Specified height level above ground"}
         actual = self.types.handle_attribute(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_attribute_2(self):
+        'Test parsing a float nan attribute'
         import math
         xml = '<attribute name="missing_value" type="float" value="NaN"/>'
         element = ET.fromstring(xml)
         expected = {"missing_value": [float("NaN")]}
         actual = self.types.handle_attribute(element)
-        assert_equal(expected.keys(), actual.keys())
+        assert expected.keys() == actual.keys()
         assert(math.isnan(actual["missing_value"][0]))
         assert(math.isnan(expected["missing_value"][0]))
 
     def test_attribute_3(self):
+        'Test parsing a float value attribute'
         xml = '<attribute name="missing_value" type="float" value="-999"/>'
         element = ET.fromstring(xml)
         expected = {"missing_value": [float(-999)]}
         actual = self.types.handle_attribute(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_attribute_4(self):
+        'Test parsing an int attribute'
         xml = '<attribute name="missing_value" type="int" value="-999"/>'
         element = ET.fromstring(xml)
         expected = {"missing_value": [-999]}
         actual = self.types.handle_attribute(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_value_1(self):
+        'Test parsing a float value tag'
         xml = '<values>2.0</values>'
         element = ET.fromstring(xml)
         expected = {"values": ["2.0"]}
         actual = self.types.handle_values(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_value_2(self):
+        'Test parsing multiple floats in a value tag'
         xml = '<values>50000.0 70000.0 85000.0</values>'
         element = ET.fromstring(xml)
         expected = {"values": ["50000.0", "70000.0", "85000.0"]}
         actual = self.types.handle_values(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_value_3(self):
+        'Test parsing multiple floats in a value tag to actual float values'
         xml = '<values>50000.0 70000.0 85000.0</values>'
         element = ET.fromstring(xml)
         expected = {"values": [50000.0, 70000.0, 85000.0]}
         actual = self.types.handle_values(element, value_type="float")
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_value_4(self):
+        'Test parsing multiple ints in a value tag to actual int values'
         xml = '<values>50000 70000 85000</values>'
         element = ET.fromstring(xml)
         expected = {"values": [50000, 70000, 85000]}
         actual = self.types.handle_values(element, value_type="int")
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_projection_box(self):
+        'Test parsing a projection box'
         xml = '<projectionBox>' \
               '<minx>-2959.1533203125</minx>' \
               '<maxx>2932.8466796875</maxx>' \
@@ -119,25 +127,28 @@ class TestSimpleTypes(object):
                                       "miny": -1827.929443359375,
                                       "maxy": 1808.070556640625}}
         actual = self.types.handle_projectionBox(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_axis_ref(self):
+        'Test parsing an axis reference'
         xml = '<axisRef name="time1"/>'
         element = ET.fromstring(xml)
 
         expected = "time1"
         actual = self.types.handle_axisRef(element)
-        assert_equal(expected, actual)
+        assert expected == actual
 
     def test_coord_trans_ref(self):
+        'Test parsing a coordinate transformation reference'
         xml = '<coordTransRef name="LambertConformal_Projection"/>'
         element = ET.fromstring(xml)
 
         expected = {"coordTransRef": "LambertConformal_Projection"}
         actual = self.types.handle_coordTransRef(element)
-        assert_equal(expected, actual)
+        assert expected == actual
 
     def test_grid(self):
+        'Test parsing a grid tag'
         xml = '<grid name="Temperature_isobaric" ' \
               'desc="Temperature @ Isobaric surface" ' \
               'shape="time1 isobaric3 y x" type="float">' \
@@ -153,18 +164,19 @@ class TestSimpleTypes(object):
                                    "missing_value": [-999.9],
                                    "Grib2_Parameter": [0, 0, 0]}}
         actual = self.types.handle_grid(element)
-        assert_dict_equal(expected["attributes"], actual["attributes"])
-        assert_dict_equal(expected.pop("attributes", None),
-                          actual.pop("attributes", None))
+        assert expected["attributes"] == actual["attributes"]
+        assert expected.pop("attributes", None) == actual.pop("attributes", None)
 
     def test_parameter(self):
+        'Test parsing a parameter tag'
         xml = '<parameter name="earth_radius" value="6371229.0 "/>'
         element = ET.fromstring(xml)
         expected = {"earth_radius": "6371229.0"}
         actual = self.types.handle_parameter(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_feature_type(self):
+        'Test parsing a feature dataset tag'
         xml = '<featureDataset type="station" ' \
               'url="/thredds/ncss/nws/metar/ncdecoded/' \
               'Metar_Station_Data_fc.cdmr"/>'
@@ -173,9 +185,10 @@ class TestSimpleTypes(object):
                     "url": "/thredds/ncss/nws/metar/ncdecoded/"
                            "Metar_Station_Data_fc.cdmr"}
         actual = self.types.handle_featureDataset(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
     def test_variable(self):
+        'Test parsing variable tags'
         xml = '<variable name="precipitation_amount_hourly" type="float">' \
               '<attribute name="long_name" ' \
               'value="Hourly precipitation amount"/>' \
@@ -192,229 +205,234 @@ class TestSimpleTypes(object):
                                    "_FillValue": [-99999.0],
                                    "units": ".01 inches"}}
         actual = self.types.handle_variable(element)
-        assert_dict_equal(expected, actual)
+        assert expected == actual
 
 
-class TestDatasetElements(object):
+def test_dataset_elements_axis():
+    'Test parsing an axis from a dataset element'
+    xml = '<axis name="height_above_ground" shape="1" type="float" ' \
+          'axisType="Height"><attribute name="units" value="m"/>' \
+          '<attribute name="long_name" ' \
+          'value="Specified height level above ground"/>' \
+          '<attribute name="positive" value="up"/><attribute ' \
+          'name="Grib_level_type" type="int" value="103"/>' \
+          '<attribute name="datum" value="ground"/>' \
+          '<attribute name="_CoordinateAxisType" value="Height"/>' \
+          '<attribute name="_CoordinateZisPositive" value="up"/>' \
+          '<values>2.0</values></axis>'
 
-    def test_axis(self):
-        xml = '<axis name="height_above_ground" shape="1" type="float" ' \
-              'axisType="Height"><attribute name="units" value="m"/>' \
-              '<attribute name="long_name" ' \
-              'value="Specified height level above ground"/>' \
-              '<attribute name="positive" value="up"/><attribute ' \
-              'name="Grib_level_type" type="int" value="103"/>' \
-              '<attribute name="datum" value="ground"/>' \
-              '<attribute name="_CoordinateAxisType" value="Height"/>' \
-              '<attribute name="_CoordinateZisPositive" value="up"/>' \
-              '<values>2.0</values></axis>'
+    element = ET.fromstring(xml)
+    actual = NCSSDataset(element).axes
+    assert actual
+    assert len(actual) == 1
+    assert actual["height_above_ground"]
+    assert len(actual["height_above_ground"]) == 4
+    assert actual["height_above_ground"]["attributes"]
+    assert len(actual["height_above_ground"]["attributes"]) == 8
 
-        element = ET.fromstring(xml)
-        actual = NCSSDataset(element).axes
-        assert actual
-        assert_equal(len(actual), 1)
-        assert actual["height_above_ground"]
-        assert_equal(len(actual["height_above_ground"]), 4)
-        assert actual["height_above_ground"]["attributes"]
-        assert_equal(len(actual["height_above_ground"]["attributes"]), 8)
 
-    def test_grid_set(self):
-        xml = '<gridSet name="time1 isobaric3 y x"><projectionBox>' \
-              '<minx>-2959.1533203125</minx>' \
-              '<maxx>2932.8466796875</maxx>' \
-              '<miny>-1827.929443359375</miny>' \
-              '<maxy>1808.070556640625</maxy>' \
-              '</projectionBox>' \
-              '<axisRef name="time1"/>' \
-              '<axisRef name="isobaric3"/>' \
-              '<axisRef name="y"/>' \
-              '<axisRef name="x"/>' \
-              '<coordTransRef name="LambertConformal_Projection"/>' \
-              '<grid name="Relative_humidity_isobaric" ' \
-              'desc="Relative humidity @ Isobaric surface" ' \
-              'shape="time1 isobaric3 y x" type="float">' \
-              '<attribute name="long_name" ' \
-              'value="Relative humidity @ Isobaric surface"/>' \
-              '<attribute name="units" value="%"/>' \
-              '<attribute name="abbreviation" value="RH"/>' \
-              '<attribute name="missing_value" type="float" value="NaN"/>' \
-              '<attribute name="grid_mapping" ' \
-              'value="LambertConformal_Projection"/>' \
-              '<attribute name="coordinates" ' \
-              'value="reftime time1 isobaric3 y x "/>' \
-              '<attribute name="Grib_Variable_Id" value="VAR_0-1-1_L100"/>' \
-              '<attribute name="Grib2_Parameter" type="int" value="0 1 1"/>' \
-              '<attribute name="Grib2_Parameter_Discipline" ' \
-              'value="Meteorological products"/>' \
-              '<attribute name="Grib2_Parameter_Category" value="Moisture"/>' \
-              '<attribute name="Grib2_Parameter_Name" ' \
-              'value="Relative humidity"/>' \
-              '<attribute name="Grib2_Level_Type" value="Isobaric surface"/>' \
-              '<attribute name="Grib2_Generating_Process_Type" ' \
-              'value="Forecast"/>' \
-              '</grid>' \
-              '<grid name="Temperature_isobaric" ' \
-              'desc="Temperature @ Isobaric surface" ' \
-              'shape="time1 isobaric3 y x" type="float">' \
-              '<attribute name="long_name" ' \
-              'value="Temperature @ Isobaric surface"/>' \
-              '<attribute name="units" value="K"/>' \
-              '<attribute name="abbreviation" value="TMP"/>' \
-              '<attribute name="missing_value" type="float" value="NaN"/>' \
-              '<attribute name="grid_mapping" ' \
-              'value="LambertConformal_Projection"/>' \
-              '<attribute name="coordinates" ' \
-              'value="reftime time1 isobaric3 y x "/>' \
-              '<attribute name="Grib_Variable_Id" value="VAR_0-0-0_L100"/>' \
-              '<attribute name="Grib2_Parameter" type="int" value="0 0 0"/>' \
-              '<attribute name="Grib2_Parameter_Discipline" ' \
-              'value="Meteorological products"/>' \
-              '<attribute name="Grib2_Parameter_Category" ' \
-              'value="Temperature"/>' \
-              '<attribute name="Grib2_Parameter_Name" value="Temperature"/>' \
-              '<attribute name="Grib2_Level_Type" value="Isobaric surface"/>' \
-              '<attribute name="Grib2_Generating_Process_Type" ' \
-              'value="Forecast"/>' \
-              '</grid>' \
-              '</gridSet>'
-        element = ET.fromstring(xml)
-        actual = NCSSDataset(element).gridsets
-        assert actual
-        assert_equal(len(actual), 1)
-        assert actual["time1 isobaric3 y x"]
-        gs = actual["time1 isobaric3 y x"]
-        assert gs["axisRef"]
-        assert_equal(len(gs["axisRef"]), 4)
-        assert gs["coordTransRef"]
-        assert gs["projectionBox"]
-        assert_equal(len(gs["projectionBox"]), 4)
-        assert gs["grid"]
-        assert_equal(len(gs["grid"]), 2)
-        for grid in gs["grid"]:
-            assert_equal(len(gs["grid"][grid]), 4)
-            assert gs["grid"][grid]["desc"]
-            assert gs["grid"][grid]["shape"]
-            assert gs["grid"][grid]["type"]
-            assert_equal(gs["grid"][grid]["type"], "float")
-            assert_equal(len(gs["grid"][grid]["attributes"]), 13)
+def test_dataset_elements_grid_set():
+    'Test parsing a gridSet from a dataset element'
+    xml = '<gridSet name="time1 isobaric3 y x"><projectionBox>' \
+          '<minx>-2959.1533203125</minx>' \
+          '<maxx>2932.8466796875</maxx>' \
+          '<miny>-1827.929443359375</miny>' \
+          '<maxy>1808.070556640625</maxy>' \
+          '</projectionBox>' \
+          '<axisRef name="time1"/>' \
+          '<axisRef name="isobaric3"/>' \
+          '<axisRef name="y"/>' \
+          '<axisRef name="x"/>' \
+          '<coordTransRef name="LambertConformal_Projection"/>' \
+          '<grid name="Relative_humidity_isobaric" ' \
+          'desc="Relative humidity @ Isobaric surface" ' \
+          'shape="time1 isobaric3 y x" type="float">' \
+          '<attribute name="long_name" ' \
+          'value="Relative humidity @ Isobaric surface"/>' \
+          '<attribute name="units" value="%"/>' \
+          '<attribute name="abbreviation" value="RH"/>' \
+          '<attribute name="missing_value" type="float" value="NaN"/>' \
+          '<attribute name="grid_mapping" ' \
+          'value="LambertConformal_Projection"/>' \
+          '<attribute name="coordinates" ' \
+          'value="reftime time1 isobaric3 y x "/>' \
+          '<attribute name="Grib_Variable_Id" value="VAR_0-1-1_L100"/>' \
+          '<attribute name="Grib2_Parameter" type="int" value="0 1 1"/>' \
+          '<attribute name="Grib2_Parameter_Discipline" ' \
+          'value="Meteorological products"/>' \
+          '<attribute name="Grib2_Parameter_Category" value="Moisture"/>' \
+          '<attribute name="Grib2_Parameter_Name" ' \
+          'value="Relative humidity"/>' \
+          '<attribute name="Grib2_Level_Type" value="Isobaric surface"/>' \
+          '<attribute name="Grib2_Generating_Process_Type" ' \
+          'value="Forecast"/>' \
+          '</grid>' \
+          '<grid name="Temperature_isobaric" ' \
+          'desc="Temperature @ Isobaric surface" ' \
+          'shape="time1 isobaric3 y x" type="float">' \
+          '<attribute name="long_name" ' \
+          'value="Temperature @ Isobaric surface"/>' \
+          '<attribute name="units" value="K"/>' \
+          '<attribute name="abbreviation" value="TMP"/>' \
+          '<attribute name="missing_value" type="float" value="NaN"/>' \
+          '<attribute name="grid_mapping" ' \
+          'value="LambertConformal_Projection"/>' \
+          '<attribute name="coordinates" ' \
+          'value="reftime time1 isobaric3 y x "/>' \
+          '<attribute name="Grib_Variable_Id" value="VAR_0-0-0_L100"/>' \
+          '<attribute name="Grib2_Parameter" type="int" value="0 0 0"/>' \
+          '<attribute name="Grib2_Parameter_Discipline" ' \
+          'value="Meteorological products"/>' \
+          '<attribute name="Grib2_Parameter_Category" ' \
+          'value="Temperature"/>' \
+          '<attribute name="Grib2_Parameter_Name" value="Temperature"/>' \
+          '<attribute name="Grib2_Level_Type" value="Isobaric surface"/>' \
+          '<attribute name="Grib2_Generating_Process_Type" ' \
+          'value="Forecast"/>' \
+          '</grid>' \
+          '</gridSet>'
+    element = ET.fromstring(xml)
+    actual = NCSSDataset(element).gridsets
+    assert actual
+    assert len(actual) == 1
+    assert actual["time1 isobaric3 y x"]
+    gs = actual["time1 isobaric3 y x"]
+    assert gs["axisRef"]
+    assert len(gs["axisRef"]) == 4
+    assert gs["coordTransRef"]
+    assert gs["projectionBox"]
+    assert len(gs["projectionBox"]) == 4
+    assert gs["grid"]
+    assert len(gs["grid"]) == 2
+    for grid in gs["grid"]:
+        assert len(gs["grid"][grid]) == 4
+        assert gs["grid"][grid]["desc"]
+        assert gs["grid"][grid]["shape"]
+        assert gs["grid"][grid]["type"]
+        assert gs["grid"][grid]["type"] == "float"
+        assert len(gs["grid"][grid]["attributes"]) == 13
 
-    def test_coord_transform_valid(self):
-        xml = '<coordTransform name="LambertConformal_Projection" ' \
-              'transformType="Projection">' \
-              '<parameter name="grid_mapping_name" ' \
-              'value="lambert_conformal_conic"/>' \
-              '<parameter name="latitude_of_projection_origin" ' \
-              'value="40.0 "/>' \
-              '<parameter name="longitude_of_central_meridian" ' \
-              'value="262.0 "/>' \
-              '<parameter name="standard_parallel" value="40.0 "/>' \
-              '<parameter name="earth_radius" value="6371229.0 "/>' \
-              '</coordTransform>'
-        element = ET.fromstring(xml)
-        actual = NCSSDataset(element).coordinate_transforms
-        assert actual
-        assert actual["LambertConformal_Projection"]
-        assert_equal(len(actual["LambertConformal_Projection"]), 2)
-        assert_equal(actual["LambertConformal_Projection"]["transformType"],
-                     "Projection")
-        parameters = actual["LambertConformal_Projection"]["parameters"]
-        assert_equal(len(parameters), 5)
-        expected = {"grid_mapping_name": "lambert_conformal_conic",
-                    "latitude_of_projection_origin": "40.0",
-                    "longitude_of_central_meridian": "262.0",
-                    "standard_parallel": "40.0",
-                    "earth_radius": "6371229.0"}
-        assert_dict_equal(parameters, expected)
 
-    def test_lat_lon_box(self):
-        xml = '<LatLonBox>' \
-              '<west>-140.1465</west>' \
-              '<east>-56.1753</east>' \
-              '<south>19.8791</south>' \
-              '<north>49.9041</north>' \
-              '</LatLonBox>'
-        element = ET.fromstring(xml)
-        expected = {"west": -140.1465,
-                    "east": -56.1753,
-                    "south": 19.8791,
-                    "north": 49.9041}
-        actual = NCSSDataset(element).lat_lon_box
-        assert actual
-        assert_dict_equal(expected, actual)
+def test_dataset_elements_coord_transform_valid():
+    'Test parsing a coordinate transformation from a dataset element'
+    xml = '<coordTransform name="LambertConformal_Projection" ' \
+          'transformType="Projection">' \
+          '<parameter name="grid_mapping_name" ' \
+          'value="lambert_conformal_conic"/>' \
+          '<parameter name="latitude_of_projection_origin" ' \
+          'value="40.0 "/>' \
+          '<parameter name="longitude_of_central_meridian" ' \
+          'value="262.0 "/>' \
+          '<parameter name="standard_parallel" value="40.0 "/>' \
+          '<parameter name="earth_radius" value="6371229.0 "/>' \
+          '</coordTransform>'
+    element = ET.fromstring(xml)
+    actual = NCSSDataset(element).coordinate_transforms
+    assert actual
+    assert actual["LambertConformal_Projection"]
+    assert len(actual["LambertConformal_Projection"]) == 2
+    assert actual["LambertConformal_Projection"]["transformType"] == "Projection"
+    parameters = actual["LambertConformal_Projection"]["parameters"]
+    assert len(parameters) == 5
+    expected = {"grid_mapping_name": "lambert_conformal_conic",
+                "latitude_of_projection_origin": "40.0",
+                "longitude_of_central_meridian": "262.0",
+                "standard_parallel": "40.0",
+                "earth_radius": "6371229.0"}
+    assert parameters == expected
 
-    def test_time_span(self):
-        xml = '<TimeSpan><begin>2015-06-19T12:00:00Z</begin>' \
-              '<end>2015-06-23T18:00:00Z</end></TimeSpan>'
-        element = ET.fromstring(xml)
-        expected = {"begin": "2015-06-19T12:00:00Z",
-                    "end": "2015-06-23T18:00:00Z"}
-        actual = NCSSDataset(element).time_span
-        assert actual
-        assert_dict_equal(expected, actual)
 
-    def test_accept_list(self):
-        xml = '<AcceptList><GridAsPoint>' \
-              '<accept displayName="xml">xml</accept>' \
-              '<accept displayName="xml (file)">xml_file</accept>' \
-              '<accept displayName="csv">csv</accept>' \
-              '<accept displayName="csv (file)">csv_file</accept>' \
-              '<accept displayName="netcdf">netcdf</accept>' \
-              '<accept displayName="netcdf4">netcdf4</accept>' \
-              '</GridAsPoint>' \
-              '<Grid>' \
-              '<accept displayName="netcdf">netcdf</accept>' \
-              '<accept displayName="netcdf4">netcdf4</accept>' \
-              '</Grid>' \
-              '</AcceptList>'
-        element = ET.fromstring(xml)
-        expected = {"GridAsPoint": ["xml", "xml_file",
-                                    "csv", "csv_file",
-                                    "netcdf", "netcdf4"],
-                    "Grid": ["netcdf", "netcdf4"]}
-        actual = NCSSDataset(element).accept_list
-        assert_dict_equal(expected, actual)
+def test_dataset_elements_lat_lon_box():
+    'Test parsing a lat/lon box from a dataset element'
+    xml = '<LatLonBox>' \
+          '<west>-140.1465</west>' \
+          '<east>-56.1753</east>' \
+          '<south>19.8791</south>' \
+          '<north>49.9041</north>' \
+          '</LatLonBox>'
+    element = ET.fromstring(xml)
+    expected = {"west": -140.1465,
+                "east": -56.1753,
+                "south": 19.8791,
+                "north": 49.9041}
+    actual = NCSSDataset(element).lat_lon_box
+    assert actual
+    assert expected == actual
 
-    def test_station_accept_list(self):
-        xml = '<AcceptList>' \
-              '<accept displayName="csv">csv</accept>' \
-              '<accept displayName="csv (file)">text/csv</accept>' \
-              '<accept displayName="xml">xml</accept>' \
-              '<accept displayName="xml (file)">text/xml</accept>' \
-              '<accept displayName="WaterML 2.0">waterml2</accept>' \
-              '<accept displayName="CF/NetCDF-3">netcdf</accept>' \
-              '<accept displayName="CF/NetCDF-4">netcdf4</accept>' \
-              '</AcceptList>'
 
-        element = ET.fromstring(xml)
-        expected = {"PointFeatureCollection": ["xml", "text/xml",
-                                               "csv", "text/csv",
-                                               "netcdf", "netcdf4",
-                                               "waterml2"]}
-        actual = NCSSDataset(element).accept_list
+def test_dataset_elements_time_span():
+    'Test parsing a TimeSpan'
+    xml = '<TimeSpan><begin>2015-06-19T12:00:00Z</begin>' \
+          '<end>2015-06-23T18:00:00Z</end></TimeSpan>'
+    element = ET.fromstring(xml)
+    expected = {"begin": "2015-06-19T12:00:00Z",
+                "end": "2015-06-23T18:00:00Z"}
+    actual = NCSSDataset(element).time_span
+    assert actual
+    assert expected == actual
 
-        assert_equal(len(actual.keys()), len(expected.keys()))
-        for accept_type in actual:
-            assert accept_type in expected
 
-        for accept_type in expected:
-            assert accept_type in actual
+def test_dataset_elements_accept_list():
+    'Test parsing an AcceptList'
+    xml = '<AcceptList><GridAsPoint>' \
+          '<accept displayName="xml">xml</accept>' \
+          '<accept displayName="xml (file)">xml_file</accept>' \
+          '<accept displayName="csv">csv</accept>' \
+          '<accept displayName="csv (file)">csv_file</accept>' \
+          '<accept displayName="netcdf">netcdf</accept>' \
+          '<accept displayName="netcdf4">netcdf4</accept>' \
+          '</GridAsPoint>' \
+          '<Grid>' \
+          '<accept displayName="netcdf">netcdf</accept>' \
+          '<accept displayName="netcdf4">netcdf4</accept>' \
+          '</Grid>' \
+          '</AcceptList>'
+    element = ET.fromstring(xml)
+    expected = {"GridAsPoint": ["xml", "xml_file",
+                                "csv", "csv_file",
+                                "netcdf", "netcdf4"],
+                "Grid": ["netcdf", "netcdf4"]}
+    actual = NCSSDataset(element).accept_list
+    assert expected == actual
 
-        assert_equal(sorted(expected["PointFeatureCollection"]),
-                     sorted(actual["PointFeatureCollection"]))
 
-    @recorder.use_cassette('Surface_Synoptic_Station_Dataset_xml')
-    def test_full_ncss_station(self):
-        url = ('http://thredds.ucar.edu/thredds/ncss/nws/synoptic/'
-               'ncdecoded/Surface_Synoptic_Point_Data_fc.cdmr/dataset.xml')
-        element = ET.fromstring(urlopen(url).read())
-        parsed = NCSSDataset(element)
-        assert parsed
+def test_dataset_elements_station_accept_list():
+    'Test parsing acceptList for stations'
+    xml = '<AcceptList>' \
+          '<accept displayName="csv">csv</accept>' \
+          '<accept displayName="csv (file)">text/csv</accept>' \
+          '<accept displayName="xml">xml</accept>' \
+          '<accept displayName="xml (file)">text/xml</accept>' \
+          '<accept displayName="WaterML 2.0">waterml2</accept>' \
+          '<accept displayName="CF/NetCDF-3">netcdf</accept>' \
+          '<accept displayName="CF/NetCDF-4">netcdf4</accept>' \
+          '</AcceptList>'
 
-    @recorder.use_cassette('GFS_Global_0p5_Grid_Dataset_xml')
-    def test_full_ncss_grid(self):
-        url = ('http://thredds.ucar.edu/thredds/ncss/grib/NCEP/GFS/'
-               'Global_0p5deg/GFS_Global_0p5deg_20150602_0000.grib2/'
-               'dataset.xml')
-        element = ET.fromstring(urlopen(url).read())
-        parsed = NCSSDataset(element)
-        assert parsed
+    element = ET.fromstring(xml)
+    expected = {"PointFeatureCollection": ["csv", "text/csv",
+                                           "xml", "text/xml",
+                                           "waterml2", "netcdf", "netcdf4"]}
+    actual = NCSSDataset(element).accept_list
+
+    assert expected == actual
+
+
+@recorder.use_cassette('Surface_Synoptic_Station_Dataset_xml')
+def test_dataset_elements_full_ncss_station():
+    'Test parsing the dataset from a full ncss station page'
+    url = ('http://thredds.ucar.edu/thredds/ncss/nws/synoptic/'
+           'ncdecoded/Surface_Synoptic_Point_Data_fc.cdmr/dataset.xml')
+    element = ET.fromstring(urlopen(url).read())
+    parsed = NCSSDataset(element)
+    assert parsed
+
+
+@recorder.use_cassette('GFS_Global_0p5_Grid_Dataset_xml')
+def test_dataset_elements_full_ncss_grid():
+    'Test parsing the dataset from a full ncss grid page'
+    url = ('http://thredds.ucar.edu/thredds/ncss/grib/NCEP/GFS/'
+           'Global_0p5deg/GFS_Global_0p5deg_20150602_0000.grib2/'
+           'dataset.xml')
+    element = ET.fromstring(urlopen(url).read())
+    parsed = NCSSDataset(element)
+    assert parsed


### PR DESCRIPTION
Fixes #81.

Nose is unmaintained and the community at large seems to be adopting py.test.

Nothing serious to convert, other than no longer using nose's helpers. py.test does sensible things with regular `assert` so this is fine.