### PR TITLE
Use OrderedDict for TDSCatalog

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,9 @@ dependencies:
   - python=3
   - requests
   - protobuf
+  # Work around current conda-forge packages on windows downloading
+  # too new of an hdf5
+  - hdf5 < 1.8.16
   - netcdf4
   - jupyter
   - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 # Create full conda environment for development, including some useful tools
 name: devel
 channels:
-  - https://conda.binstar.org/conda-forge
+  - https://conda.anaconda.org/conda-forge
 dependencies:
   - python=3
   - requests
@@ -16,4 +16,3 @@ dependencies:
   - pep8-naming
   - matplotlib
   - xarray
-  - jupyter_client!=4.2.1

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -9,6 +9,7 @@ the latest dataset and finding proper URLs to access the data.
 
 import logging
 import xml.etree.ElementTree as ET
+from collections import OrderedDict
 
 from .metadata import TDSCatalogMetadata
 from .http_util import create_http_session, urlopen
@@ -80,9 +81,9 @@ class TDSCatalog(object):
         else:
             self.catalog_name = "No name found"
 
-        self.datasets = {}
+        self.datasets = OrderedDict()
         self.services = []
-        self.catalog_refs = {}
+        self.catalog_refs = OrderedDict()
         self.metadata = {}
         service_skip_count = 0
         service_skip = 0

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -89,3 +89,21 @@ class TestCatalog(object):
         ref_name = 'Forecast Model Data'
         cat = TDSCatalog(url).catalog_refs[ref_name].follow()
         assert cat
+
+    @recorder.use_cassette('top_level_20km_rap_catalog')
+    def test_datasets_order(self):
+        url = ('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/'
+               'CONUS_20km/noaaport/catalog.xml')
+        cat = TDSCatalog(url)
+        assert list(cat.datasets) == ['Full Collection (Reference / Forecast Time) Dataset',
+                                      'Best NAM CONUS 20km Time Series',
+                                      'Latest Collection for NAM CONUS 20km']
+
+    @recorder.use_cassette('top_level_cat')
+    def test_catalog_ref_order(self):
+        url = 'http://thredds.ucar.edu/thredds/catalog.xml'
+        cat = TDSCatalog(url)
+        assert list(cat.catalog_refs) == ['Forecast Model Data',
+                                          'Forecast Products and Analyses', 'Observation Data',
+                                          'Radar Data', 'Satellite Data',
+                                          'Unidata case studies']

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -15,95 +15,112 @@ log.addHandler(logging.StreamHandler())
 recorder = get_recorder(__file__)
 
 
-class TestCatalog(object):
-    baseURL = 'http://thredds-test.unidata.ucar.edu/thredds/'
+@recorder.use_cassette('thredds-test-toplevel-catalog')
+def test_basic():
+    'Basic test of catalog parsing'
+    url = 'http://thredds-test.unidata.ucar.edu/thredds/catalog.xml'
+    cat = TDSCatalog(url)
+    assert 'Forecast Model Data' in cat.catalog_refs
 
-    @recorder.use_cassette('thredds-test-toplevel-catalog')
-    def test_basic(self):
-        url = self.baseURL + 'catalog.xml'
-        cat = TDSCatalog(url)
-        assert 'Forecast Model Data' in cat.catalog_refs
 
-    @recorder.use_cassette('thredds-test-latest-gfs-0p5')
-    def test_access(self):
-        url = self.baseURL + 'catalog/grib/NCEP/GFS/Global_0p5deg/latest.xml'
-        cat = TDSCatalog(url)
-        ds = list(cat.datasets.values())[0]
-        assert 'OPENDAP' in ds.access_urls
+@recorder.use_cassette('thredds-test-latest-gfs-0p5')
+def test_access():
+    'Test catalog parsing of access methods'
+    url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/grib/'
+           'NCEP/GFS/Global_0p5deg/latest.xml')
+    cat = TDSCatalog(url)
+    ds = list(cat.datasets.values())[0]
+    assert 'OPENDAP' in ds.access_urls
 
-    @recorder.use_cassette('top_level_20km_rap_catalog')
-    def test_virtual_access(self):
-        url = ('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/'
-               'CONUS_20km/noaaport/catalog.xml')
-        cat = TDSCatalog(url)
-        # find the 2D time coordinate "full collection" dataset
-        for dataset in list(cat.datasets.values()):
-            if "Full Collection" in dataset.name:
-                ds = dataset
-                break
-        assert 'OPENDAP' in ds.access_urls
-        # TwoD is a virtual dataset, so HTTPServer
-        # should not be listed here
-        assert 'HTTPServer' not in ds.access_urls
 
-    @recorder.use_cassette('latest_rap_catalog')
-    def test_get_latest(self):
+@recorder.use_cassette('top_level_20km_rap_catalog')
+def test_virtual_access():
+    'Test access of virtual datasets'
+    url = ('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/'
+           'CONUS_20km/noaaport/catalog.xml')
+    cat = TDSCatalog(url)
+    # find the 2D time coordinate "full collection" dataset
+    for dataset in list(cat.datasets.values()):
+        if "Full Collection" in dataset.name:
+            ds = dataset
+            break
+    assert 'OPENDAP' in ds.access_urls
+    # TwoD is a virtual dataset, so HTTPServer
+    # should not be listed here
+    assert 'HTTPServer' not in ds.access_urls
+
+
+@recorder.use_cassette('latest_rap_catalog')
+def test_get_latest():
+    'Test latest dataset helper function'
+    url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
+           'grib/NCEP/RAP/CONUS_13km/catalog.xml')
+    latest_url = get_latest_access_url(url, "OPENDAP")
+    assert latest_url
+
+
+@recorder.use_cassette('top_level_cat')
+def test_tds_top_catalog():
+    'Test parsing top-level catalog'
+    url = 'http://thredds.ucar.edu/thredds/catalog.xml'
+    cat = TDSCatalog(url)
+    assert cat
+
+
+@recorder.use_cassette('radar_dataset_cat')
+def test_simple_radar_cat():
+    'Test parsing of radar server catalog'
+    url = 'http://thredds.ucar.edu/thredds/radarServer/nexrad/level2/' \
+          'IDD/dataset.xml'
+    cat = TDSCatalog(url)
+    assert cat
+
+
+@recorder.use_cassette('point_feature_dataset_xml')
+def test_simple_point_feature_collection_xml():
+    'Test accessing point feature top-level catalog'
+    url = ('http://thredds.ucar.edu/thredds/catalog/nws/metar/ncdecoded/catalog.xml'
+           '?dataset=nws/metar/ncdecoded/Metar_Station_Data_fc.cdmr')
+    cat = TDSCatalog(url)
+    assert cat
+
+
+@recorder.use_cassette('html_then_xml_catalog')
+def test_html_link():
+    'Test that we fall-back when given an HTML catalog page'
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
         url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
-               'grib/NCEP/RAP/CONUS_13km/catalog.xml')
-        latest_url = get_latest_access_url(url, "OPENDAP")
-        assert latest_url
-
-    @recorder.use_cassette('top_level_cat')
-    def test_tds_top_catalog(self):
-        url = 'http://thredds.ucar.edu/thredds/catalog.xml'
+               'grib/NCEP/RAP/CONUS_13km/catalog.html')
         cat = TDSCatalog(url)
         assert cat
 
-    @recorder.use_cassette('radar_dataset_cat')
-    def test_simple_radar_cat(self):
-        url = 'http://thredds.ucar.edu/thredds/radarServer/nexrad/level2/' \
-              'IDD/dataset.xml'
-        cat = TDSCatalog(url)
-        assert cat
 
-    @recorder.use_cassette('point_feature_dataset_xml')
-    def test_simple_point_feature_collection_xml(self):
-        url = 'http://thredds.ucar.edu/thredds/catalog/nws/metar/' \
-              'ncdecoded/catalog.xml?dataset=nws/metar/ncdecoded' \
-              '/Metar_Station_Data_fc.cdmr'
-        cat = TDSCatalog(url)
-        assert cat
+@recorder.use_cassette('follow_cat')
+def test_catalog_follow():
+    'Test catalog reference following'
+    url = 'http://thredds.ucar.edu/thredds/catalog.xml'
+    ref_name = 'Forecast Model Data'
+    cat = TDSCatalog(url).catalog_refs[ref_name].follow()
+    assert cat
 
-    @recorder.use_cassette('html_then_xml_catalog')
-    def test_html_link(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
-                   'grib/NCEP/RAP/CONUS_13km/catalog.html')
-            cat = TDSCatalog(url)
-            assert cat
 
-    @recorder.use_cassette('follow_cat')
-    def test_catalog_follow(self):
-        url = 'http://thredds.ucar.edu/thredds/catalog.xml'
-        ref_name = 'Forecast Model Data'
-        cat = TDSCatalog(url).catalog_refs[ref_name].follow()
-        assert cat
+@recorder.use_cassette('top_level_20km_rap_catalog')
+def test_datasets_order():
+    'Test that we properly order datasets parsed from the catalog'
+    url = ('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/'
+           'CONUS_20km/noaaport/catalog.xml')
+    cat = TDSCatalog(url)
+    assert list(cat.datasets) == ['Full Collection (Reference / Forecast Time) Dataset',
+                                  'Best NAM CONUS 20km Time Series',
+                                  'Latest Collection for NAM CONUS 20km']
 
-    @recorder.use_cassette('top_level_20km_rap_catalog')
-    def test_datasets_order(self):
-        url = ('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/'
-               'CONUS_20km/noaaport/catalog.xml')
-        cat = TDSCatalog(url)
-        assert list(cat.datasets) == ['Full Collection (Reference / Forecast Time) Dataset',
-                                      'Best NAM CONUS 20km Time Series',
-                                      'Latest Collection for NAM CONUS 20km']
 
-    @recorder.use_cassette('top_level_cat')
-    def test_catalog_ref_order(self):
-        url = 'http://thredds.ucar.edu/thredds/catalog.xml'
-        cat = TDSCatalog(url)
-        assert list(cat.catalog_refs) == ['Forecast Model Data',
-                                          'Forecast Products and Analyses', 'Observation Data',
-                                          'Radar Data', 'Satellite Data',
-                                          'Unidata case studies']
+@recorder.use_cassette('top_level_cat')
+def test_catalog_ref_order():
+    'Test that catalog references are properly ordered'
+    url = 'http://thredds.ucar.edu/thredds/catalog.xml'
+    cat = TDSCatalog(url)
+    assert list(cat.catalog_refs) == ['Forecast Model Data', 'Forecast Products and Analyses',
+                                      'Observation Data', 'Radar Data', 'Satellite Data',
+                                      'Unidata case studies']

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import warnings
 
 from siphon.testing import get_recorder
 from siphon.catalog import TDSCatalog, get_latest_access_url
@@ -75,10 +76,12 @@ class TestCatalog(object):
 
     @recorder.use_cassette('html_then_xml_catalog')
     def test_html_link(self):
-        url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
-               'grib/NCEP/RAP/CONUS_13km/catalog.html')
-        cat = TDSCatalog(url)
-        assert cat
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
+                   'grib/NCEP/RAP/CONUS_13km/catalog.html')
+            cat = TDSCatalog(url)
+            assert cat
 
     @recorder.use_cassette('follow_cat')
     def test_catalog_follow(self):


### PR DESCRIPTION
This uses OrderedDict to store datasets and catalog refs. This gives those items in the order they appear in the catalog, which is more sensible.