### PR TITLE
Latest dataset issue

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -400,8 +400,7 @@ def _get_latest_cat(catalog_url):
     """
     cat = TDSCatalog(catalog_url)
     for service in cat.services:
-        if (service.name.lower() == "latest" and
-                service.service_type.lower() == "resolver"):
+        if (service.service_type.lower() == "resolver"):
             latest_cat = cat.catalog_url.replace("catalog.xml", "latest.xml")
             return TDSCatalog(latest_cat)
 

--- a/siphon/metadata.py
+++ b/siphon/metadata.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 import logging
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.WARNING)
+log.setLevel(logging.ERROR)
 
 
 class _SimpleTypes(object):


### PR DESCRIPTION
In TDS 4.6, the latest service had a `name` of `Latest` and a `serviceType` of `Resolver`, at least on Unidata servers. In 5.0, the name has changed to simply `Resolver`, as part of the new Standard Service feature. The name was always configurable by the server admin, so there is no need to explicitly check the `service` elements `name` attribute.

Also in this PR is change to make invalid values for THREDDS Catalog Metadata less noisy, as they are not all that importiant for the end users to see. This second commit sets the log level to ERROR instead of WARNING.