### PR TITLE
Fix validation warning in tests

### DIFF
--- a/siphon/metadata.py
+++ b/siphon/metadata.py
@@ -12,6 +12,7 @@ import logging
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.ERROR)
+log.addHandler(logging.StreamHandler())
 
 
 class _SimpleTypes(object):

--- a/siphon/tests/fixtures/cat_non_standard_context_path
+++ b/siphon/tests/fixtures/cat_non_standard_context_path
@@ -17,7 +17,7 @@ interactions:
         \ serviceType=\"HTTPServer\" base=\"/ereefs/tds/fileServer/\" />\r\n  </service>\r\
         \n  <dataset name=\"P1A\" ID=\"mwq/P1A\">\r\n    <metadata inherited=\"true\"\
         >\r\n      <serviceName>nongrid</serviceName>\r\n      <authority>au.gov.bom</authority>\r\
-        \n      <dataType>GRID</dataType>\r\n      <dataFormat>netCDF</dataFormat>\r\
+        \n      <dataType>GRID</dataType>\r\n      <dataFormat>NetCDF</dataFormat>\r\
         \n      <documentation type=\"rights\">Registered research users only</documentation>\r\
         \n    </metadata>\r\n    <dataset name=\"A20020101.P1A.ANN_MIM_RMP.nc\" ID=\"\
         mwq/P1A/A20020101.P1A.ANN_MIM_RMP.nc\" urlPath=\"ereef/mwq/P1A/A20020101.P1A.ANN_MIM_RMP.nc\"\

--- a/siphon/tests/test_metadata.py
+++ b/siphon/tests/test_metadata.py
@@ -9,7 +9,6 @@ from siphon.metadata import _ComplexTypes, _SimpleTypes, TDSCatalogMetadata
 
 log = logging.getLogger('siphon.metadata')
 log.setLevel(logging.WARNING)
-log.addHandler(logging.StreamHandler())
 
 #
 # tested:
@@ -105,9 +104,7 @@ class TestComplexTypes(object):
                     'size': 20.6,
                     'units': 'degrees_north'}
         element = ET.fromstring(xml)
-        actual = {}
-        for child in element:
-            actual.update(self.st.handle_spatialRange(element))
+        actual = self.st.handle_spatialRange(element)
 
         assert actual == expected
 
@@ -346,7 +343,8 @@ class TestGeospatialCoverage(object):
 
 class TestMetadata(object):
 
-    def _make_element(self, xml_str):
+    @staticmethod
+    def _make_element(xml_str):
         return ET.fromstring(xml_str)
 
     def test_documentation_element_no_type(self):
@@ -497,6 +495,12 @@ class TestMetadata(object):
         md = TDSCatalogMetadata(element).metadata
         assert 'dataFormat' in md
         assert md['dataFormat'] == 'GRIB-1'
+
+    def test_data_malformed_format(self, capfd):
+        xml = '<dataFormat>netCDF-4</dataFormat>'
+        element = self._make_element(xml)
+        TDSCatalogMetadata(element)
+        assert 'Value netCDF-4 not valid for type dataFormat' in ''.join(capfd.readouterr())
 
     def test_data_type(self):
         xml = '<dataType>GRID</dataType>'


### PR DESCRIPTION
We get a validation warning in our test suite due to an attribute added to a catalog that is not under our control.