### PR TITLE
Handle more data types when parsing dataset.xml

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ sphinx_gallery_conf = {
     'examples_dirs': ['../examples'],
     'gallery_dirs': ['examples'],
     'filename_pattern': '/',
-    'mod_example_dir': 'api/generated'
+    'backreferences_dir': 'api/generated'
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -369,7 +369,7 @@ class SimpleService(object):
         self.name = service_node.attrib['name']
         self.service_type = service_node.attrib['serviceType']
         self.base = service_node.attrib['base']
-        self.access_urls = dict()
+        self.access_urls = {}
 
 
 class CompoundService(object):

--- a/siphon/ncss.py
+++ b/siphon/ncss.py
@@ -271,7 +271,7 @@ class ResponseRegistry(object):
     '''
 
     def __init__(self):
-        self._reg = dict()
+        self._reg = {}
 
     def register(self, mimetype):
         def dec(func):
@@ -300,7 +300,7 @@ def squish(l):
 def combine_dicts(l):
     r'Combine a list of dictionaries into single one'
 
-    ret = dict()
+    ret = {}
     for item in l:
         ret.update(item)
     return ret
@@ -314,8 +314,8 @@ def parse_xml(data, handle_units):
 
 
 def parse_xml_point(elem):
-    point = dict()
-    units = dict()
+    point = {}
+    units = {}
     for data in elem.findall('data'):
         name = data.get('name')
         unit = data.get('units')
@@ -326,7 +326,7 @@ def parse_xml_point(elem):
 
 
 def combine_xml_points(l, units, handle_units):
-    ret = dict()
+    ret = {}
     for item in l:
         for key, value in item.items():
             ret.setdefault(key, []).append(value)
@@ -341,7 +341,7 @@ def combine_xml_points(l, units, handle_units):
 def parse_xml_dataset(elem, handle_units):
     points, units = zip(*[parse_xml_point(p) for p in elem.findall('point')])
     # Group points by the contents of each point
-    datasets = dict()
+    datasets = {}
     for p in points:
         datasets.setdefault(tuple(p.keys()), []).append(p)
 
@@ -393,7 +393,7 @@ def parse_csv_response(data, unit_handler):
 
 
 def parse_csv_header(line):
-    units = dict()
+    units = {}
     names = []
     for var in line.split(','):
         start = var.find('[')
@@ -416,7 +416,7 @@ def parse_csv_dataset(data, handle_units):
     names, units = parse_csv_header(fobj.readline().decode('utf-8'))
     arrs = np.genfromtxt(fobj, dtype=None, names=names, delimiter=',', unpack=True,
                          converters={'date': lambda s: parse_iso_date(s.decode('utf-8'))})
-    d = dict()
+    d = {}
     for f in arrs.dtype.fields:
         dat = arrs[f]
         if dat.dtype == np.object:

--- a/siphon/ncss_dataset.py
+++ b/siphon/ncss_dataset.py
@@ -294,12 +294,12 @@ class NCSSDataset(object):
     def _parse_element(self, element):
         element_name = element.tag
 
-        parser = dict(gridSet=self._parse_gridset, axis=self._parse_axis,
-                      coordTransform=self._parse_coordTransform,
-                      LatLonBox=self._parse_LatLonBox, TimeSpan=self._parse_TimeSpan,
-                      AcceptList=self._parse_AcceptList,
-                      featureDataset=self._parse_featureDataset,
-                      variable=self._parse_variable)
+        parser = {'gridSet': self._parse_gridset, 'axis': self._parse_axis,
+                  'coordTransform': self._parse_coordTransform,
+                  'LatLonBox': self._parse_LatLonBox, 'TimeSpan': self._parse_TimeSpan,
+                  'AcceptList': self._parse_AcceptList,
+                  'featureDataset': self._parse_featureDataset,
+                  'variable': self._parse_variable}
 
         try:
             parser[element_name](element)

--- a/siphon/tests/test_ncss_dataset.py
+++ b/siphon/tests/test_ncss_dataset.py
@@ -11,7 +11,6 @@ from siphon.testing import get_recorder
 
 log = logging.getLogger('siphon.ncss_dataset')
 log.setLevel(logging.WARNING)
-log.addHandler(logging.StreamHandler())
 
 recorder = get_recorder(__file__)
 
@@ -45,15 +44,97 @@ class TestSimpleTypes(object):
     def setup_class(cls):
         cls.types = _Types()
 
-    def test_attribute_1(self):
-        'Test parsing a string attribute'
-        xml = '<attribute name="long_name" value="Specified height level above ground"/>'
+    def test_attribute_byte(self):
+        'Test parsing a byte attribute'
+        xml = '<attribute name="missing_value" type="byte" value="1"/>'
         element = ET.fromstring(xml)
-        expected = {'long_name': 'Specified height level above ground'}
+        expected = {'missing_value': [1]}
         actual = self.types.handle_attribute(element)
         assert expected == actual
 
-    def test_attribute_2(self):
+    def test_attribute_invalid_byte(self, capfd):
+        'Test parsing an invalid byte attribute'
+        xml = '<attribute name="missing_value" type="byte" value="a"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': ['a']}
+        actual = self.types.handle_attribute(element)
+        expected_message = 'Cannot convert [\'a\'] to int. Keeping type as str.'
+        assert expected_message in ''.join(capfd.readouterr())
+        assert expected == actual
+
+    def test_attribute_short(self):
+        'Test parsing a short attribute'
+        xml = '<attribute name="missing_value" type="short" value="-999"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': [-999]}
+        actual = self.types.handle_attribute(element)
+        assert expected == actual
+
+    def test_attribute_invalid_short(self, capfd):
+        'Test parsing an invalid short attribute'
+        xml = '<attribute name="missing_value" type="short" value="a"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': ['a']}
+        actual = self.types.handle_attribute(element)
+        expected_message = 'Cannot convert [\'a\'] to int. Keeping type as str.'
+        assert expected_message in ''.join(capfd.readouterr())
+        assert expected == actual
+
+    def test_attribute_int(self):
+        'Test parsing an int attribute'
+        xml = '<attribute name="missing_value" type="int" value="-999"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': [-999]}
+        actual = self.types.handle_attribute(element)
+        assert expected == actual
+
+    def test_attribute_invalid_int(self, capfd):
+        'Test parsing an invalid int attribute'
+        xml = '<attribute name="missing_value" type="int" value="a"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': ['a']}
+        actual = self.types.handle_attribute(element)
+        expected_message = 'Cannot convert [\'a\'] to int. Keeping type as str.'
+        assert expected_message in ''.join(capfd.readouterr())
+        assert expected == actual
+
+    def test_attribute_long(self):
+        'Test parsing a long attribute'
+        xml = '<attribute name="missing_value" type="long" value="-999"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': [-999]}
+        actual = self.types.handle_attribute(element)
+        assert expected == actual
+
+    def test_attribute_invalid_long(self, capfd):
+        'Test parsing a invalid long attribute'
+        xml = '<attribute name="missing_value" type="long" value="a"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': ['a']}
+        actual = self.types.handle_attribute(element)
+        expected_message = 'Cannot convert [\'a\'] to int. Keeping type as str.'
+        assert expected_message in ''.join(capfd.readouterr())
+        assert expected == actual
+
+    def test_attribute_float(self):
+        'Test parsing a float value attribute'
+        xml = '<attribute name="missing_value" type="float" value="-999.0"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': [float(-999.0)]}
+        actual = self.types.handle_attribute(element)
+        assert expected == actual
+
+    def test_attribute_invalid_float(self, capfd):
+        'Test parsing an invalid float value attribute'
+        xml = '<attribute name="missing_value" type="float" value="a"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': ['a']}
+        actual = self.types.handle_attribute(element)
+        expected_message = 'Cannot convert [\'a\'] to float. Keeping type as str.'
+        assert expected_message in ''.join(capfd.readouterr())
+        assert expected == actual
+
+    def test_attribute_float_nan(self):
         'Test parsing a float nan attribute'
         import math
         xml = '<attribute name="missing_value" type="float" value="NaN"/>'
@@ -64,20 +145,77 @@ class TestSimpleTypes(object):
         assert(math.isnan(actual['missing_value'][0]))
         assert(math.isnan(expected['missing_value'][0]))
 
-    def test_attribute_3(self):
-        'Test parsing a float value attribute'
-        xml = '<attribute name="missing_value" type="float" value="-999"/>'
+    def test_attribute_double(self):
+        'Test parsing a double attribute'
+        xml = '<attribute name="missing_value" type="double" value="-999.0"/>'
         element = ET.fromstring(xml)
-        expected = {'missing_value': [float(-999)]}
+        expected = {'missing_value': [-999.0]}
         actual = self.types.handle_attribute(element)
         assert expected == actual
 
-    def test_attribute_4(self):
-        'Test parsing an int attribute'
-        xml = '<attribute name="missing_value" type="int" value="-999"/>'
+    def test_attribute_invalid_double(self, capfd):
+        'Test parsing an invalid double attribute'
+        xml = '<attribute name="missing_value" type="double" value="a"/>'
         element = ET.fromstring(xml)
-        expected = {'missing_value': [-999]}
+        expected = {'missing_value': ['a']}
         actual = self.types.handle_attribute(element)
+        expected_message = 'Cannot convert [\'a\'] to float. Keeping type as str.'
+        assert expected_message in ''.join(capfd.readouterr())
+        assert expected == actual
+
+    def test_attribute_double_nan(self):
+        'Test parsing a double nan attribute'
+        import math
+        xml = '<attribute name="missing_value" type="double" value="NaN"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': [float('NaN')]}
+        actual = self.types.handle_attribute(element)
+        assert expected.keys() == actual.keys()
+        assert(math.isnan(actual['missing_value'][0]))
+        assert(math.isnan(expected['missing_value'][0]))
+
+    def test_attribute_string_implicit(self):
+        'Test parsing a string attribute'
+        xml = '<attribute name="long_name" value="Specified height level above ground"/>'
+        element = ET.fromstring(xml)
+        expected = {'long_name': 'Specified height level above ground'}
+        actual = self.types.handle_attribute(element)
+        assert expected == actual
+
+    def test_attribute_string_explicit(self):
+        'Test parsing a string attribute'
+        xml = '<attribute name="long_name" type="String" ' \
+              'value="Specified height level above ground"/>'
+        element = ET.fromstring(xml)
+        expected = {'long_name': ['Specified height level above ground']}
+        actual = self.types.handle_attribute(element)
+        assert expected == actual
+
+    def test_attribute_boolean_true(self):
+        'Test parsing a boolean attribute'
+        xml = '<attribute name="missing_value" type="boolean" value="true"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': [True]}
+        actual = self.types.handle_attribute(element)
+        assert expected == actual
+
+    def test_attribute_boolean_false(self):
+        'Test parsing a boolean attribute'
+        xml = '<attribute name="missing_value" type="boolean" value="false"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': [False]}
+        actual = self.types.handle_attribute(element)
+        assert expected == actual
+
+    def test_attribute_boolean_invalid(self, capfd):
+        'Test parsing an invalid boolean attribute'
+        xml = '<attribute name="missing_value" type="boolean" value="a"/>'
+        element = ET.fromstring(xml)
+        expected = {'missing_value': ['a']}
+        actual = self.types.handle_attribute(element)
+        expected_message = 'Cannot convert values [\'a\'] to boolean.'
+        expected_message += ' Keeping type as str.'
+        assert expected_message in ''.join(capfd.readouterr())
         assert expected == actual
 
     def test_value_1(self):


### PR DESCRIPTION
Before these changes, we only handled types `int` and `float` when parsing dataset.xml - everything else was left as a string and logged a warning. Even with this PR, we still do not handle:

 * Sequence
 * Structure
 * enum
 * opaque
 * object
 * char

because I do not have an example of those, and honestly have no idea what to do with some.