### PR TITLE
BUG: Fix empty set returned from validate_query (Fixes #102)

### DIFF
--- a/siphon/ncss.py
+++ b/siphon/ncss.py
@@ -88,7 +88,7 @@ class NCSS(HTTPEndPoint):
 
         """
         # Make sure all variables are in the dataset
-        return query.var and all(var in self.variables for var in query.var)
+        return bool(query.var) and all(var in self.variables for var in query.var)
 
     def get_data(self, query):
         """Fetch parsed data from a THREDDS server using NCSS.

--- a/siphon/tests/test_ncss.py
+++ b/siphon/tests/test_ncss.py
@@ -92,6 +92,13 @@ class TestNCSS(object):
         self.nq.variables('foo')
         assert not self.ncss.validate_query(self.nq)
 
+    def test_empty_query(self):
+        """Test that an empty query is invalid."""
+        query = self.ncss.query()
+        res = self.ncss.validate_query(query)
+        assert not res
+        assert not isinstance(res, set)
+
     def test_bad_query_no_vars(self):
         """Test that a query without variables is invalid."""
         self.nq.var.clear()


### PR DESCRIPTION
Manually cast set of variables to bool when returning.