### PR TITLE
BUG: Fix access_urls for some services

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ install:
     # Use the pre-installed Miniconda for the desired arch
     - ps: if($env:PYTHON_VERSION -eq '3.6')
             { $env:CONDA_PATH="$($env:CONDA_PATH)36" }
-    - ps: if($env:TARGET_ARCH -eq 'x64')
+    - ps: if($env:PLATFORM -eq 'x64')
             { $env:CONDA_PATH="$($env:CONDA_PATH)-x64" }
     - ps: $env:path="$($env:CONDA_PATH);$($env:CONDA_PATH)\Scripts;$($env:CONDA_PATH)\Library\bin;C:\cygwin\bin;$($env:PATH)"
     - cmd: conda config --set always_yes yes --set changeps1 no

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = siphon/_version.py,siphon/cdmr/*_pb2.py,*/tests/*
+omit = siphon/_version.py,siphon/cdmr/*_pb2.py

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -410,15 +410,18 @@ class Dataset(object):
             The top level server url
         all_services : List[SimpleService]
             list of :class:`SimpleService` objects associated with the dataset
-        metadata : TDSCatalogMetadata
+        metadata : dict
             Metadata from the :class:`TDSCatalog`
 
         """
-        all_service_dict = {service.name: service for service in all_services}
-        service_name = None
-        if metadata:
-            if 'serviceName' in metadata:
-                service_name = metadata['serviceName']
+        all_service_dict = {}
+        for service in all_services:
+            all_service_dict[service.name] = service
+            if isinstance(service, CompoundService):
+                for subservice in service.services:
+                    all_service_dict[subservice.name] = subservice
+
+        service_name = metadata.get('serviceName', None)
 
         access_urls = {}
         server_url = _find_base_tds_url(catalog_url)

--- a/siphon/tests/fixtures/cat_only_http
+++ b/siphon/tests/fixtures/cat_only_http
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.5.0+13.g0e639e9.dirty)]
+    method: GET
+    uri: http://thredds-test.unidata.ucar.edu/thredds/catalog/noaaport/text/tropical/atlantic/hdob/catalog.xml
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<catalog xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.2\">\r\n  <service
+        name=\"latest\" serviceType=\"Resolver\" base=\"\" />\r\n  <service name=\"fullServices\"
+        serviceType=\"Compound\" base=\"\">\r\n    <service name=\"ncdods\" serviceType=\"OPENDAP\"
+        base=\"/thredds/dodsC/\" />\r\n    <service name=\"HTTPServer\" serviceType=\"HTTPServer\"
+        base=\"/thredds/fileServer/\" />\r\n    <service name=\"wcs\" serviceType=\"WCS\"
+        base=\"/thredds/wcs/\" />\r\n    <service name=\"wms\" serviceType=\"WMS\"
+        base=\"/thredds/wms/\" />\r\n    <service name=\"ncss\" serviceType=\"NetcdfSubset\"
+        base=\"/thredds/ncss/\" />\r\n    <service name=\"cdmremote\" serviceType=\"CdmRemote\"
+        base=\"/thredds/cdmremote/\" />\r\n    <service name=\"gridcoverage\" serviceType=\"CdmrFeature\"
+        base=\"/thredds/cdmrfeature/grid/\" />\r\n    <service name=\"ncml\" serviceType=\"NCML\"
+        base=\"/thredds/ncml/\" />\r\n    <service name=\"uddc\" serviceType=\"UDDC\"
+        base=\"/thredds/uddc/\" />\r\n    <service name=\"iso\" serviceType=\"ISO\"
+        base=\"/thredds/iso/\" />\r\n  </service>\r\n  <dataset name=\"tropical/atlantic/hdob/\">\r\n
+        \   <serviceName>HTTPServer</serviceName>\r\n    <property name=\"DatasetScan\"
+        value=\"true\" />\r\n    <metadata inherited=\"true\">\r\n      <serviceName>HTTPServer</serviceName>\r\n
+        \   </metadata>\r\n    <dataset name=\"High_density_obs_20170824.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170824.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170824.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">11.75</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-08-25T00:00:27Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170825.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170825.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170825.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">357.0</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-08-25T23:54:05Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170826.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170826.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170826.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">63.33</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-08-26T05:46:05Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170828.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170828.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170828.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">51.55</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-08-28T21:00:06Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170829.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170829.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170829.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">32.40</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-08-29T19:46:07Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170831.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170831.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170831.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">10.31</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-08-31T23:42:07Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170902.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170902.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170902.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">55.67</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-09-02T22:48:00Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170903.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170903.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170903.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">73.25</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-09-03T23:53:07Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170904.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170904.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170904.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">268.5</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-09-05T00:05:12Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"High_density_obs_20170905.txt\" ID=\"noaaport-text/tropical/atlantic/hdob/High_density_obs_20170905.txt\"
+        urlPath=\"noaaport/text/tropical/atlantic/hdob/High_density_obs_20170905.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">320.1</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2017-09-05T23:36:21Z</date>\r\n
+        \   </dataset>\r\n  </dataset>\r\n</catalog>\r\n"}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [Keep-Alive]
+      Content-Language: [en-US]
+      Content-Type: [application/xml;charset=UTF-8]
+      Date: ['Tue, 05 Sep 2017 23:38:46 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache/2.4.27 (Unix) OpenSSL/1.0.1e-fips mod_jk/1.2.42]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: '200'}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.5.0+13.g0e639e9.dirty)]
+    method: GET
+    uri: http://thredds-test.unidata.ucar.edu/thredds/catalog/noaaport/text/tropical/atlantic/hdob/latest.xml
+  response:
+    body: {string: 'Throwable exception handled : null'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [close]
+      Content-Length: ['34']
+      Content-Type: [text/plain]
+      Date: ['Tue, 05 Sep 2017 23:38:48 GMT']
+      Server: [Apache/2.4.27 (Unix) OpenSSL/1.0.1e-fips mod_jk/1.2.42]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 500, message: '500'}
+version: 1

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -216,3 +216,14 @@ def test_access_elements():
     url = 'http://oceandata.sci.gsfc.nasa.gov/opendap/SeaWiFS/L3SMI/2001/001/catalog.xml'
     cat = TDSCatalog(url)
     assert len(list(cat.datasets)) != 0
+
+
+@recorder.use_cassette('cat_only_http')
+def test_simple_service_within_compound():
+    """Test parsing of a catalog that asks for a single service within a compound one."""
+    url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/noaaport/text/'
+           'tropical/atlantic/hdob/catalog.xml')
+    cat = TDSCatalog(url)
+    assert (cat.datasets[0].access_urls ==
+            {'HTTPServer': 'http://thredds-test.unidata.ucar.edu/thredds/fileServer/noaaport/'
+                           'text/tropical/atlantic/hdob/High_density_obs_20170824.txt'})


### PR DESCRIPTION
Catalogs are allowed to specify the name of a service that is contained
within a compound service. Siphon was not properly creating the access
urls dictionary for this case.