### PR TITLE
Printing/repr improvements

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -129,6 +129,10 @@ class DatasetCollection(IndexableMapping):
         return [item[-1] for item in self._get_datasets_with_times(regex)
                 if start <= item[0] <= end]
 
+    def __str__(self):
+        """Return a string representation of the collection."""
+        return str(list(self))
+
 
 class TDSCatalog(object):
     """

--- a/siphon/cdmr/dataset.py
+++ b/siphon/cdmr/dataset.py
@@ -122,6 +122,8 @@ class Group(AttributeContainer):
                 print_groups.append('\t{}: {}'.format(att, getattr(self, att)))
         return '\n'.join(print_groups)
 
+    __repr__ = __str__
+
 
 class Dataset(Group):
     """Abstract away access to the remote dataset."""
@@ -143,6 +145,8 @@ class Dataset(Group):
     def __str__(self):
         """Return a string representation of the Dataset and all contained members."""
         return self.url + '\n' + super(Dataset, self).__str__()
+
+    __repr__ = __str__
 
 
 class Variable(AttributeContainer):
@@ -372,3 +376,5 @@ class Dimension(object):
             grps.append(', size = {0}'.format(self.size))
 
         return ''.join(grps)
+
+    __repr__ = __str__

--- a/siphon/cdmr/tests/test_dataset.py
+++ b/siphon/cdmr/tests/test_dataset.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert_array_equal
+import pytest
 
 from siphon.cdmr import Dataset
 from siphon.testing import get_recorder
@@ -318,10 +319,11 @@ def test_unsigned_var():
 
 
 @recorder.use_cassette('nc4_groups')
-def test_print():
-    """Test that __str__ (or printing) a dataset works."""
+@pytest.mark.parametrize('func', [str, repr])
+def test_print(func):
+    """Test that str and repr of a dataset work."""
     ds = Dataset('http://localhost:8080/thredds/cdmremote/nc4/tst/tst_groups.nc')
-    s = str(ds)
+    s = func(ds)
     truth = """http://localhost:8080/thredds/cdmremote/nc4/tst/tst_groups.nc
 Groups:
 g1

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -140,6 +140,17 @@ def test_datasets_get_by_index():
 
 
 @recorder.use_cassette('top_level_20km_rap_catalog')
+def test_datasets_str():
+    """Test that datasets are printed as expected."""
+    url = ('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/'
+           'CONUS_20km/noaaport/catalog.xml')
+    cat = TDSCatalog(url)
+    assert str(cat.datasets) == ("['Full Collection (Reference / Forecast Time) Dataset', "
+                                 "'Best NAM CONUS 20km Time Series', "
+                                 "'Latest Collection for NAM CONUS 20km']")
+
+
+@recorder.use_cassette('top_level_20km_rap_catalog')
 def test_datasets_nearest_time():
     """Test getting dataset by time using filenames."""
     url = ('http://thredds.ucar.edu/thredds/catalog/grib/NCEP/NAM/'

--- a/siphon/tests/test_ncss.py
+++ b/siphon/tests/test_ncss.py
@@ -184,7 +184,7 @@ class TestNCSS(object):
         self.nq.accept('csv').vertical_level(50000)
         csv_data = self.ncss.get_data(self.nq)
 
-        assert str(csv_data['Temperature_isobaric'])[:6] == '263.39'
+        np.testing.assert_almost_equal(csv_data['Temperature_isobaric'], np.array([263.40]), 2)
 
     @recorder.use_cassette('ncss_gfs_csv_point')
     def test_raw_csv(self):


### PR DESCRIPTION
This has a few improvements to string representations and printing to help when working interactively (i.e. in the notebook)

- Add `__repr__` (which is just the same as `__str__`) to `Dataset` and friends for the CDM Remote interface. This just makes it easier to get to them in the notebook
- Add a `__str__` method to `catalog.datasets` to make it easier to print out what datasets are available without needing to manually call `list`.