### PR TITLE
MNT: Fix style lint from flake8 3.5

### DIFF
--- a/siphon/tests/test_http_util.py
+++ b/siphon/tests/test_http_util.py
@@ -125,11 +125,11 @@ def test_data_query_items():
     """Test the items method of query."""
     dt = datetime.utcnow()
     dr = DataQuery().time(dt).lonlat_point(-1, -2)
-    l = list(dr.items())
+    items = list(dr.items())
 
-    assert ('time', dt.isoformat()) in l
-    assert ('latitude', -2) in l
-    assert ('longitude', -1) in l
+    assert ('time', dt.isoformat()) in items
+    assert ('latitude', -2) in items
+    assert ('longitude', -1) in items
 
 
 def test_data_query_add():


### PR DESCRIPTION
It now warns about variables named 'l', since they are easily confused
with '1'. Changing all of these did seem to result in better code
regardless.