### PR TITLE
Various catalog fixes

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -186,7 +186,7 @@ class TDSCatalog(object):
             resp.raise_for_status()
 
         # begin parsing the xml doc
-        root = ET.fromstring(resp.text)
+        root = ET.fromstring(resp.content)
         self.catalog_name = root.attrib.get('name', 'No name found')
 
         self.datasets = DatasetCollection()

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -165,15 +165,15 @@ class TDSCatalog(object):
             The URL of a THREDDS client catalog
 
         """
-        # top level server url
-        self.catalog_url = catalog_url
-        self.base_tds_url = _find_base_tds_url(catalog_url)
-
         session = create_http_session()
 
         # get catalog.xml file
-        resp = session.get(self.catalog_url)
+        resp = session.get(catalog_url)
         resp.raise_for_status()
+
+        # top level server url
+        self.catalog_url = resp.url
+        self.base_tds_url = _find_base_tds_url(self.catalog_url)
 
         # If we were given an HTML link, warn about it and try to fix to xml
         if 'html' in resp.headers['content-type']:

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -305,8 +305,8 @@ class CatalogRef(object):
             An :class:`~xml.etree.ElementTree.Element` representing a catalogRef node
 
         """
-        self.name = element_node.attrib['name']
         self.title = element_node.attrib['{http://www.w3.org/1999/xlink}title']
+        self.name = element_node.attrib.get('name', self.title)
 
         # Resolve relative URLs
         href = element_node.attrib['{http://www.w3.org/1999/xlink}href']

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -440,21 +440,19 @@ class Dataset(object):
                 # for each SimpleService
                 if isinstance(service, CompoundService):
                     for subservice in service.services:
-                        access_urls[subservice.service_type] = (server_url +
-                                                                subservice.base +
-                                                                self.url_path)
+                        server_base = urljoin(server_url, subservice.base)
+                        access_urls[subservice.service_type] = urljoin(server_base,
+                                                                       self.url_path)
                 else:
-                    access_urls[service.service_type] = (server_url +
-                                                         service.base +
-                                                         self.url_path)
+                    server_base = urljoin(server_url, service.base)
+                    access_urls[service.service_type] = urljoin(server_base, self.url_path)
 
         # process access children of dataset elements
         for service_type in self.access_element_info:
             url_path = self.access_element_info[service_type]
             if service_type in all_service_dict:
-                access_urls[service_type] = (server_url +
-                                             all_service_dict[service_type].base +
-                                             url_path)
+                server_base = urljoin(server_url, all_service_dict[service_type].base)
+                access_urls[service_type] = urljoin(server_base, url_path)
 
         self.access_urls = access_urls
 

--- a/siphon/cdmr/tests/test_coveragedataset.py
+++ b/siphon/cdmr/tests/test_coveragedataset.py
@@ -3,17 +3,15 @@
 # SPDX-License-Identifier: MIT
 """Test Coverage Dataset."""
 
-import warnings
+import pytest
 
 from siphon.cdmr.coveragedataset import CoverageDataset
 from siphon.testing import get_recorder
 
 recorder = get_recorder(__file__)
 
-# Ignore warnings about CoverageDataset
-warnings.simplefilter('ignore')
 
-
+@pytest.mark.filterwarnings('ignore: CoverageDataset')
 @recorder.use_cassette('hrrr_cdmremotefeature')
 def test_simple_cdmremotefeature():
     """Smoke test for CDMRemoteFeature."""
@@ -22,6 +20,7 @@ def test_simple_cdmremotefeature():
     assert cd.grids
 
 
+@pytest.mark.filterwarnings('ignore: CoverageDataset')
 @recorder.use_cassette('hrrr_cdmremotefeature')
 def test_simple_cdmremotefeature_str():
     """Smoke test for converting CoverageDataset to str."""

--- a/siphon/radarserver.py
+++ b/siphon/radarserver.py
@@ -85,7 +85,7 @@ class RadarServer(HTTPEndPoint):
 
     def _get_stations(self, station_file='stations.xml'):
         resp = self.get_path(station_file)
-        self.stations = parse_station_table(ET.fromstring(resp.text))
+        self.stations = parse_station_table(ET.fromstring(resp.content))
 
     def query(self):
         """Return a new query for the radar server.

--- a/siphon/simplewebservice/wyoming.py
+++ b/siphon/simplewebservice/wyoming.py
@@ -4,12 +4,15 @@
 """Read upper air data from the Wyoming archives."""
 
 from io import StringIO
+import warnings
 
 from bs4 import BeautifulSoup
 import numpy as np
 import pandas as pd
 from .._tools import get_wind_components
 from ..http_util import HTTPEndPoint
+
+warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created', UserWarning)
 
 
 class WyomingUpperAir(HTTPEndPoint):

--- a/siphon/tests/fixtures/rsmas_ramadda
+++ b/siphon/tests/fixtures/rsmas_ramadda
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.0+16.gce11082.dirty)]
+    method: GET
+    uri: http://weather.rsmas.miami.edu/repository?output=thredds.catalog
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><catalog name=\"RSMAS-UM
+        Repository for atm-ocean data and its science\" xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n  <dataset name=\"RSMAS-UM
+        Repository for atm-ocean data and its science\">\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=5c0355aa-bcc1-4b90-808f-48ecc03b7989&amp;output=thredds.catalog\"
+        xlink:title=\"AMIE-DYNAMO data archive\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=e1ae1cc5-4a1e-4bcf-bc24-8497c9c2bffd&amp;output=thredds.catalog\"
+        xlink:title=\"Annual Cycle Explorer software and description: tinyurl.com/MapesACE\"/>\n
+        \   <catalogRef xlink:href=\"/repository/entry/show?entryid=d7ce4aa0-7266-47d7-89d7-e84a505d89e2&amp;output=thredds.catalog\"
+        xlink:title=\"CAROB Miami observatory data archive\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=07f6a773-fee4-4dd6-9a09-619db75e157f&amp;output=thredds.catalog\"
+        xlink:title=\"Chen lab\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=424f384c-91ad-42b3-b6c5-a5b0cc90b53d&amp;output=thredds.catalog\"
+        xlink:title=\"Datasets hosted on this UM server\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=0f166334-728e-4344-87ee-7a847399eca6&amp;output=thredds.catalog\"
+        xlink:title=\"GCM nudging project\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=e0ab8229-9dad-431a-b478-71e5607e37e9&amp;output=thredds.catalog\"
+        xlink:title=\"South Asian Monsoon loops\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=45e3b50b-dbe2-408b-a6c2-2c009749cd53&amp;output=thredds.catalog\"
+        xlink:title=\"The Mapes IDV collection\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=b221d8d3-46d5-44f1-8d8e-d1d5ebc24d2d&amp;output=thredds.catalog\"
+        xlink:title=\"UM course related stuff\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=08512ac5-7509-411c-971b-88efdc283bda&amp;output=thredds.catalog\"
+        xlink:title=\"Users\"/>\n    <catalogRef xlink:href=\"http://esrl.noaa.gov/gsd/thredds/hrrr.xml\"
+        xlink:title=\"HRRR model from NOAA-GSD\"/>\n    <catalogRef xlink:href=\"http://weather.rsmas.miami.edu/thredds/catalog.xml\"
+        xlink:title=\"THREDDS data catalog on weather.rsmas.miami.edu\"/>\n  </dataset>\n</catalog>\n"}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2258']
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Tue, 31 Oct 2017 21:17:47 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache]
+      Set-Cookie: ['ramadda_repository_session=b95d312c-74c4-464e-81d2-1ba4be8597f0_0.468476777107967;
+          path=/repository; expires=Tue, 26-Oct-2021 23:59:59 GMT']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: '200'}
+version: 1

--- a/siphon/tests/fixtures/rsmas_ramadda_datasets
+++ b/siphon/tests/fixtures/rsmas_ramadda_datasets
@@ -1,0 +1,203 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.0+18.g872e2b9.dirty)]
+    method: GET
+    uri: http://weather.rsmas.miami.edu/repository?output=thredds.catalog
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><catalog name=\"RSMAS-UM
+        Repository for atm-ocean data and its science\" xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n  <dataset name=\"RSMAS-UM
+        Repository for atm-ocean data and its science\">\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=5c0355aa-bcc1-4b90-808f-48ecc03b7989&amp;output=thredds.catalog\"
+        xlink:title=\"AMIE-DYNAMO data archive\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=e1ae1cc5-4a1e-4bcf-bc24-8497c9c2bffd&amp;output=thredds.catalog\"
+        xlink:title=\"Annual Cycle Explorer software and description: tinyurl.com/MapesACE\"/>\n
+        \   <catalogRef xlink:href=\"/repository/entry/show?entryid=d7ce4aa0-7266-47d7-89d7-e84a505d89e2&amp;output=thredds.catalog\"
+        xlink:title=\"CAROB Miami observatory data archive\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=07f6a773-fee4-4dd6-9a09-619db75e157f&amp;output=thredds.catalog\"
+        xlink:title=\"Chen lab\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=424f384c-91ad-42b3-b6c5-a5b0cc90b53d&amp;output=thredds.catalog\"
+        xlink:title=\"Datasets hosted on this UM server\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=0f166334-728e-4344-87ee-7a847399eca6&amp;output=thredds.catalog\"
+        xlink:title=\"GCM nudging project\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=e0ab8229-9dad-431a-b478-71e5607e37e9&amp;output=thredds.catalog\"
+        xlink:title=\"South Asian Monsoon loops\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=45e3b50b-dbe2-408b-a6c2-2c009749cd53&amp;output=thredds.catalog\"
+        xlink:title=\"The Mapes IDV collection\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=b221d8d3-46d5-44f1-8d8e-d1d5ebc24d2d&amp;output=thredds.catalog\"
+        xlink:title=\"UM course related stuff\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=08512ac5-7509-411c-971b-88efdc283bda&amp;output=thredds.catalog\"
+        xlink:title=\"Users\"/>\n    <catalogRef xlink:href=\"http://esrl.noaa.gov/gsd/thredds/hrrr.xml\"
+        xlink:title=\"HRRR model from NOAA-GSD\"/>\n    <catalogRef xlink:href=\"http://weather.rsmas.miami.edu/thredds/catalog.xml\"
+        xlink:title=\"THREDDS data catalog on weather.rsmas.miami.edu\"/>\n  </dataset>\n</catalog>\n"}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2258']
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Tue, 31 Oct 2017 22:39:54 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache]
+      Set-Cookie: ['ramadda_repository_session=01515177-fb6e-4d76-ad7e-d534916cc3ee_0.5596476352415347;
+          path=/repository; expires=Tue, 26-Oct-2021 23:59:59 GMT']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: '200'}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.0+18.g872e2b9.dirty)]
+    method: GET
+    uri: http://weather.rsmas.miami.edu/repository/entry/show?entryid=5c0355aa-bcc1-4b90-808f-48ecc03b7989&output=thredds.catalog
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><catalog name=\"AMIE-DYNAMO
+        data archive\" xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n  <dataset name=\"AMIE-DYNAMO
+        data archive\">\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=a43c1cc4-1cf2-4365-97b9-6768b8201407&amp;output=thredds.catalog\"
+        xlink:title=\"CSU gridded analyses\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=601aa404-ac59-4abb-8c4f-11c08474a214&amp;output=thredds.catalog\"
+        xlink:title=\"ECMWF analyses 0.25deg pressure grib1 format\"/>\n    <catalogRef
+        xlink:href=\"/repository/entry/show?entryid=46f345ab-ef00-43f2-9942-1c2266149a7e&amp;output=thredds.catalog\"
+        xlink:title=\"IDV bundles and displays\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=7b8b8367-0db3-43f6-b622-7325463babb3&amp;output=thredds.catalog\"
+        xlink:title=\"MIMIC Column water vapor - morphed\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=ead0b8a3-905a-4b6c-b466-7aec80b20cbf&amp;output=thredds.catalog\"
+        xlink:title=\"MJO and BSISO filtered OLR\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=982a2587-ce6c-4315-8e04-d9f646ee8937&amp;output=thredds.catalog\"
+        xlink:title=\"Revelle ship radar (3D volumes)\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=f1c24657-2c1d-4b30-96c1-c0c0302c593b&amp;output=thredds.catalog\"
+        xlink:title=\"SPOL radial data - but IDV doesn't recognize CF-radial format\"/>\n
+        \   <catalogRef xlink:href=\"/repository/entry/show?entryid=862c2b55-353b-468a-8b7e-21557841cc2b&amp;output=thredds.catalog\"
+        xlink:title=\"SPOL survey scans 15min in 2011\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=044f91c5-8fb4-47e6-8971-2520f71a03a2&amp;output=thredds.catalog\"
+        xlink:title=\"SSMI daily products from RSS\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=e36d2a07-045f-42ff-ab06-9dab8cc91a76&amp;output=thredds.catalog\"
+        xlink:title=\"Smart-R CYLBIN hourly files -- tar\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=0ae53955-8426-4e9f-8902-ec3b066d661f&amp;output=thredds.catalog\"
+        xlink:title=\"TRMM and IR satellite grids\"/>\n    <dataset name=\"Gan radiometer+wind\">\n
+        \     <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/document-excel-csv.png\"/>\n
+        \     <property name=\"ramadda.id\" value=\"1ae6a83e-6a5e-4776-8dbe-4517a534a8ee\"/>\n
+        \     <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \     <access serviceName=\"http\" urlPath=\"/Gan.UV+PW_LWP.csv?entryid=1ae6a83e-6a5e-4776-8dbe-4517a534a8ee\"/>\n
+        \     <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/page.png\"/>\n
+        \     <dataSize units=\"bytes\">141262</dataSize>\n      <date type=\"metadataCreated\">2014-09-26
+        02:56:17 UTC</date>\n      <timeCoverage>\n        <start>2014-09-26 02:56:17
+        UTC</start>\n        <end>2014-09-26 02:56:17 UTC</end>\n      </timeCoverage>\n
+        \   </dataset>\n    <dataset name=\"PW_withGan_7views\">\n      <property
+        name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/idv/idv.gif\"/>\n
+        \     <property name=\"ramadda.id\" value=\"8a63f80d-09b4-4007-b07b-7dc3d47caf9a\"/>\n
+        \     <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \     <access serviceName=\"http\" urlPath=\"/PW_withGan_7views.xidv?entryid=8a63f80d-09b4-4007-b07b-7dc3d47caf9a\"/>\n
+        \     <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/page.png\"/>\n
+        \     <property name=\"thumbnail\" value=\"http://weather.rsmas.miami.edu/repository/metadata/view/PW_withGan_7views.gif?element=1&amp;entryid=8a63f80d-09b4-4007-b07b-7dc3d47caf9a&amp;metadata.id=8bddb0f2-be5e-43c7-9c28-cbf35e65cc69\"/>\n
+        \     <dataSize units=\"bytes\">472724</dataSize>\n      <date type=\"metadataCreated\">2014-09-26
+        14:54:19 UTC</date>\n      <timeCoverage>\n        <start>2011-11-24 00:00:00
+        UTC</start>\n        <end>2011-11-29 00:00:00 UTC</end>\n      </timeCoverage>\n
+        \   </dataset>\n  </dataset>\n  <service base=\"http://weather.rsmas.miami.edu/repository/entry/get\"
+        name=\"http\" serviceType=\"http\"/>\n</catalog>\n"}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['4034']
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Tue, 31 Oct 2017 22:39:54 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache]
+      Set-Cookie: ['ramadda_repository_session=76be331f-cd5a-443c-a119-947f7d1a28be_0.1308195297232102;
+          path=/repository; expires=Tue, 26-Oct-2021 23:59:59 GMT']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: '200'}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.0+18.g872e2b9.dirty)]
+    method: GET
+    uri: http://weather.rsmas.miami.edu/repository/entry/show?entryid=a43c1cc4-1cf2-4365-97b9-6768b8201407&output=thredds.catalog
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><catalog name=\"CSU
+        gridded analyses\" xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n  <dataset name=\"CSU gridded
+        analyses\">\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YyYl91c2VzRUNPQQ%3D%3D&amp;output=thredds.catalog\"
+        xlink:title=\"v2b_usesECOA\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YyYV9vYnNvbmx5&amp;output=thredds.catalog\"
+        xlink:title=\"v2a_obsonly\"/>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YxYQ%3D%3D&amp;output=thredds.catalog\"
+        xlink:title=\"v1a\"/>\n  </dataset>\n</catalog>\n"}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['793']
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Tue, 31 Oct 2017 22:39:54 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache]
+      Set-Cookie: ['ramadda_repository_session=af5601b1-1eae-4702-b80e-63859747829d_0.8163946096633592;
+          path=/repository; expires=Tue, 26-Oct-2021 23:59:59 GMT']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: '200'}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.0+18.g872e2b9.dirty)]
+    method: GET
+    uri: http://weather.rsmas.miami.edu/repository/entry/show?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YyYl91c2VzRUNPQQ%3D%3D&output=thredds.catalog
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><catalog name=\"v2b_usesECOA\"
+        xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n
+        \ <dataset name=\"v2b_usesECOA\">\n    <dataset name=\"Latest v2b_usesECOA\">\n
+        \     <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/cdmdata/opendap.gif\"/>\n
+        \     <access serviceName=\"latest\" urlPath=\"/latest?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YyYl91c2VzRUNPQQ%3D%3D&amp;latestopendap=true&amp;output=thredds.catalog\"/>\n
+        \   </dataset>\n    <catalogRef xlink:href=\"/repository/entry/show?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YyYl91c2VzRUNPQS9wbG90cw%3D%3D&amp;output=thredds.catalog\"
+        xlink:title=\"plots\"/>\n    <dataset name=\"Readme.txt\">\n      <property
+        name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/page.png\"/>\n
+        \     <property name=\"ramadda.id\" value=\"synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9SZWFkbWUudHh0\"/>\n
+        \     <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \     <access serviceName=\"http\" urlPath=\"/Readme.txt?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YyYl91c2VzRUNPQS9SZWFkbWUudHh0\"/>\n
+        \     <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/page.png\"/>\n
+        \     <dataSize units=\"bytes\">6302</dataSize>\n      <date type=\"metadataCreated\">2014-04-10
+        21:49:19 UTC</date>\n      <timeCoverage>\n        <start>2014-04-10 21:49:19
+        UTC</start>\n        <end>2014-04-10 21:49:19 UTC</end>\n      </timeCoverage>\n
+        \   </dataset>\n    <dataset name=\"dynamo_derived_v2b_2011all.nc\">\n      <property
+        name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/page.png\"/>\n
+        \     <property name=\"ramadda.id\" value=\"synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fZGVyaXZlZF92MmJfMjAxMWFsbC5uYw==\"/>\n
+        \     <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \     <access serviceName=\"opendap\" urlPath=\"/synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fZGVyaXZlZF92MmJfMjAxMWFsbC5uYw==/entry.das\"/>\n
+        \     <dataset name=\"OPeNDAP Link\">\n        <property name=\"ramadda.id\"
+        value=\"synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fZGVyaXZlZF92MmJfMjAxMWFsbC5uYw==\"/>\n
+        \       <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \       <access serviceName=\"opendap\" urlPath=\"http://weather.rsmas.miami.edu/repository/opendap/synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fZGVyaXZlZF92MmJfMjAxMWFsbC5uYw==/entry.das\"/>\n
+        \       <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/cdmdata/opendap.gif\"/>\n
+        \     </dataset>\n      <dataset name=\"File download\">\n        <property
+        name=\"ramadda.id\" value=\"synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fZGVyaXZlZF92MmJfMjAxMWFsbC5uYw==\"/>\n
+        \       <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \       <access serviceName=\"http\" urlPath=\"/dynamo_derived_v2b_2011all.nc?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YyYl91c2VzRUNPQS9keW5hbW9fZGVyaXZlZF92MmJfMjAxMWFsbC5uYw%3D%3D\"/>\n
+        \       <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/page.png\"/>\n
+        \     </dataset>\n      <dataSize units=\"bytes\">2921048216</dataSize>\n
+        \     <date type=\"metadataCreated\">2014-04-12 21:10:27 UTC</date>\n      <timeCoverage>\n
+        \       <start>2014-04-12 21:10:27 UTC</start>\n        <end>2014-04-12 21:10:27
+        UTC</end>\n      </timeCoverage>\n    </dataset>\n    <dataset name=\"dynamo_basic_v2b_2011all.nc\">\n
+        \     <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/page.png\"/>\n
+        \     <property name=\"ramadda.id\" value=\"synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fYmFzaWNfdjJiXzIwMTFhbGwubmM=\"/>\n
+        \     <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \     <access serviceName=\"opendap\" urlPath=\"/synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fYmFzaWNfdjJiXzIwMTFhbGwubmM=/entry.das\"/>\n
+        \     <dataset name=\"OPeNDAP Link\">\n        <property name=\"ramadda.id\"
+        value=\"synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fYmFzaWNfdjJiXzIwMTFhbGwubmM=\"/>\n
+        \       <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \       <access serviceName=\"opendap\" urlPath=\"http://weather.rsmas.miami.edu/repository/opendap/synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fYmFzaWNfdjJiXzIwMTFhbGwubmM=/entry.das\"/>\n
+        \       <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/cdmdata/opendap.gif\"/>\n
+        \     </dataset>\n      <dataset name=\"File download\">\n        <property
+        name=\"ramadda.id\" value=\"synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c2VzRUNPQS9keW5hbW9fYmFzaWNfdjJiXzIwMTFhbGwubmM=\"/>\n
+        \       <property name=\"ramadda.host\" value=\"weather.rsmas.miami.edu\"/>\n
+        \       <access serviceName=\"http\" urlPath=\"/dynamo_basic_v2b_2011all.nc?entryid=synth%3Aa43c1cc4-1cf2-4365-97b9-6768b8201407%3AL3YyYl91c2VzRUNPQS9keW5hbW9fYmFzaWNfdjJiXzIwMTFhbGwubmM%3D\"/>\n
+        \       <property name=\"icon\" value=\"http://weather.rsmas.miami.edu/repository/icons/page.png\"/>\n
+        \     </dataset>\n      <dataSize units=\"bytes\">2935653172</dataSize>\n
+        \     <date type=\"metadataCreated\">2014-04-12 21:11:13 UTC</date>\n      <timeCoverage>\n
+        \       <start>2014-04-12 21:11:13 UTC</start>\n        <end>2014-04-12 21:11:13
+        UTC</end>\n      </timeCoverage>\n    </dataset>\n  </dataset>\n  <service
+        base=\"http://weather.rsmas.miami.edu/repository/entry/get\" name=\"http\"
+        serviceType=\"http\"/>\n  <service base=\"http://weather.rsmas.miami.edu/repository/opendap\"
+        name=\"opendap\" serviceType=\"opendap\"/>\n  <service base=\"http://weather.rsmas.miami.edu/repository/entry/show\"
+        name=\"latest\" serviceType=\"Resolver\"/>\n</catalog>\n"}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['5790']
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Tue, 31 Oct 2017 22:39:54 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache]
+      Set-Cookie: ['ramadda_repository_session=5ef56a35-e108-48f7-b4fc-b187ebc7dab7_0.5765682928071657;
+          path=/repository; expires=Tue, 26-Oct-2021 23:59:59 GMT']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: '200'}
+version: 1

--- a/siphon/tests/fixtures/tds50_catalogref_follow
+++ b/siphon/tests/fixtures/tds50_catalogref_follow
@@ -1,0 +1,616 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.0+19.g94704ea.dirty)]
+    method: GET
+    uri: http://thredds-test.unidata.ucar.edu/thredds/catalog.xml
+  response:
+    body: {string: ''}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [Keep-Alive]
+      Content-Language: [en-US]
+      Content-Length: ['0']
+      Content-Type: [application/xml]
+      Date: ['Wed, 01 Nov 2017 03:51:55 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Location: [/thredds/catalog/catalog.xml]
+      Server: [Apache/2.4.27 (Unix) OpenSSL/1.0.1e-fips mod_jk/1.2.42]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 302, message: '302'}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.0+19.g94704ea.dirty)]
+    method: GET
+    uri: http://thredds-test.unidata.ucar.edu/thredds/catalog/catalog.xml
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<catalog xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\" name=\"Unidata THREDDS Data Server\"
+        version=\"1.2\">\r\n  <dataset name=\"Realtime data from IDD\">\r\n    <catalogRef
+        xlink:href=\"idd/forecastModels.xml\" xlink:title=\"Forecast Model Data\"
+        name=\"Forecast Model Data\" />\r\n    <catalogRef xlink:href=\"idd/forecastProdsAndAna.xml\"
+        xlink:title=\"Forecast Products and Analyses\" name=\"Forecast Products and
+        Analyses\" />\r\n    <catalogRef xlink:href=\"idd/obsData.xml\" xlink:title=\"Observation
+        Data\" name=\"Observation Data\" />\r\n    <catalogRef xlink:href=\"idd/radars.xml\"
+        xlink:title=\"Radar Data\" name=\"Radar Data\" />\r\n    <catalogRef xlink:href=\"idd/satellite.xml\"
+        xlink:title=\"Satellite Data\" name=\"Satellite Data\" />\r\n  </dataset>\r\n
+        \ <dataset name=\"Other Unidata Data\">\r\n    <catalogRef xlink:href=\"casestudies/catalog.xml\"
+        xlink:title=\"Unidata case studies\" name=\"Unidata case studies\" />\r\n
+        \ </dataset>\r\n  <dataset name=\"Test Datasets\">\r\n    <catalogRef xlink:href=\"testDatasets.xml\"
+        xlink:title=\"Test Datasets\" name=\"Test Datasets\" />\r\n    <catalogRef
+        xlink:href=\"testPointDatasets.xml\" xlink:title=\"Test Point Datasets\" name=\"Test
+        Point Datasets\" />\r\n    <catalogRef xlink:href=\"cf_examples.xml\" xlink:title=\"CF
+        DSG Example Datasets\" name=\"CF DSG Example Datasets\" />\r\n  </dataset>\r\n
+        \ <dataset name=\"For GRIB Indexing Purposes\">\r\n    <catalogRef xlink:href=\"modelsHrrr.xml\"
+        xlink:title=\"Test Point Datasets\" name=\"Test Point Datasets\" />\r\n  </dataset>\r\n</catalog>\r\n"}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [Keep-Alive]
+      Content-Language: [en-US]
+      Content-Type: [application/xml;charset=UTF-8]
+      Date: ['Wed, 01 Nov 2017 03:51:55 GMT']
+      Keep-Alive: ['timeout=5, max=99']
+      Server: [Apache/2.4.27 (Unix) OpenSSL/1.0.1e-fips mod_jk/1.2.42]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: '200'}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.0+19.g94704ea.dirty)]
+    method: GET
+    uri: http://thredds-test.unidata.ucar.edu/thredds/catalog/idd/forecastModels.xml
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<catalog xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\" name=\"Unidata THREDDS Data Server
+        - NCEP models\" version=\"1.2\">\r\n  <service name=\"latest\" serviceType=\"Resolver\"
+        base=\"\" />\r\n  <service name=\"fullServices\" serviceType=\"Compound\"
+        base=\"\">\r\n    <service name=\"opendap\" serviceType=\"OPENDAP\" base=\"/thredds/dodsC/\"
+        />\r\n    <service name=\"HTTPServer\" serviceType=\"HTTPServer\" base=\"/thredds/fileServer/\"
+        />\r\n    <service name=\"wcs\" serviceType=\"WCS\" base=\"/thredds/wcs/\"
+        />\r\n    <service name=\"wms\" serviceType=\"WMS\" base=\"/thredds/wms/\"
+        />\r\n    <service name=\"ncss\" serviceType=\"NetcdfSubset\" base=\"/thredds/ncss/\"
+        />\r\n    <service name=\"cdmremote\" serviceType=\"CdmRemote\" base=\"/thredds/cdmremote/\"
+        />\r\n    <service name=\"ncml\" serviceType=\"NCML\" base=\"/thredds/ncml/\"
+        />\r\n    <service name=\"uddc\" serviceType=\"UDDC\" base=\"/thredds/uddc/\"
+        />\r\n    <service name=\"iso\" serviceType=\"ISO\" base=\"/thredds/iso/\"
+        />\r\n  </service>\r\n  <dataset name=\"NCEP Forecast Models\">\r\n    <metadata
+        inherited=\"true\">\r\n      <serviceName>fullServices</serviceName>\r\n      <authority>edu.ucar.unidata</authority>\r\n
+        \     <dataType>GRID</dataType>\r\n      <dataFormat>GRIB-2</dataFormat>\r\n
+        \     <documentation xlink:href=\"http://www.emc.ncep.noaa.gov/modelinfo/index.html\"
+        xlink:title=\"NCEP Model documentation\" />\r\n      <documentation type=\"rights\">Freely
+        available</documentation>\r\n      <documentation type=\"processing_level\">Transmitted
+        through Unidata Internet Data Distribution.</documentation>\r\n      <documentation
+        type=\"processing_level\">Read by CDM Grib Collection.</documentation>\r\n
+        \     <documentation xlink:href=\"http://www.nco.ncep.noaa.gov/pmb/nwprod/analysis/\"
+        xlink:title=\"NCEP/NWS Model Analyses and Forecasts page\" />\r\n      <documentation
+        xlink:href=\"http://www.unidata.ucar.edu/data/index.html#model\" xlink:title=\"Unidata
+        IDD Model Data page\" />\r\n      <creator>\r\n        <name vocabulary=\"DIF\">DOC/NOAA/NWS/NCEP</name>\r\n
+        \       <contact url=\"http://www.ncep.noaa.gov/\" email=\"http://www.ncep.noaa.gov/mail_liaison.shtml\"
+        />\r\n      </creator>\r\n      <creator>\r\n        <name vocabulary=\"ADN\">National
+        Oceanic and Atmospheric Administration (NOAA)/National Weather Service (NWS)\r\n
+        \         National Center for Environmental Prediction (NCEP)</name>\r\n        <contact
+        url=\"http://www.ncep.noaa.gov/\" email=\"http://www.ncep.noaa.gov/mail_liaison.shtml\"
+        />\r\n      </creator>\r\n      <publisher>\r\n        <name vocabulary=\"DIF\">UCAR/UNIDATA</name>\r\n
+        \       <contact url=\"http://www.unidata.ucar.edu/\" email=\"support@unidata.ucar.edu\"
+        />\r\n      </publisher>\r\n      <publisher>\r\n        <name vocabulary=\"ADN\">University
+        Corporation for Atmospheric Research (UCAR)/Unidata</name>\r\n        <contact
+        url=\"http://www.unidata.ucar.edu/\" email=\"support@unidata.ucar.edu\" />\r\n
+        \     </publisher>\r\n      <timeCoverage>\r\n        <end>present</end>\r\n
+        \       <duration>45 days</duration>\r\n      </timeCoverage>\r\n    </metadata>\r\n
+        \   <dataset name=\"Global Ensemble Forecasting System (GEFS)\">\r\n      <metadata
+        inherited=\"true\">\r\n        <documentation type=\"summary\">NCEP Global
+        Ensemble Forecasting System (GEFS) Global one degree Lat/Lon grid. Model runs
+        are made at 0, 6, 12, 18 ... hours out to 378 hours (16 days). Horizontal
+        = 181 by 360 points, resolution 1 degree, Lat/Lon projection. Vertical = 2000
+        to 1000 hPa mandatory pressure levels (7 levels); pressure, height above ground,
+        pressure_difference_layers.</documentation>\r\n      </metadata>\r\n      <catalogRef
+        xlink:href=\"/thredds/catalog/grib/NCEP/GEFS/Global_1p0deg_Ensemble/members-analysis/catalog.xml\"
+        xlink:title=\"GEFS Members - Analysis\" name=\"GEFS Members - Analysis\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">Ensemble
+        members - Analysis grids only.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GEFS/Global_1p0deg_Ensemble/members/catalog.xml\"
+        xlink:title=\"GEFS Members - Forecasts\" name=\"GEFS Members - Forecasts\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">Ensemble members.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GEFS/Global_1p0deg_Ensemble/derived/catalog.xml\"
+        xlink:title=\"GEFS Derived Forecast Products\" name=\"GEFS Derived Forecast
+        Products\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">Ensemble derived products: mean,
+        spread, and probabilities.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \   </dataset>\r\n    <dataset name=\"Global Forecast System (GFS)\">\r\n
+        \     <metadata inherited=\"true\">\r\n        <documentation type=\"summary\">NCEP
+        Global Forecast System Model, previously called AVN/MRF (Medium Range Forecast)</documentation>\r\n
+        \       <documentation xlink:href=\"http://meted.ucar.edu/nwp/pcu2/avintro.htm\"
+        xlink:title=\"COMET MetEd (Meteorology Education and Training) documentation\"
+        />\r\n        <documentation xlink:href=\"http://www.nco.ncep.noaa.gov/pmb/products/gfs/\"
+        xlink:title=\"NCEP Model Notes\" />\r\n      </metadata>\r\n      <dataset
+        name=\"GFS Quarter Degree - Global Coverage\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP GFS Model : AWIPS 230 (G) Grid.
+        Global Lat/Lon grid. Model runs at 0, 6, 12, and 18Z. Horizontal= 721 by 14400
+        points, resolution 0.25 degree, Lat/Lon projection. Vertical= 1000 to 100
+        hPa mandatory pressure levels (26 levels); surface, height above ground, pressure
+        layers.</documentation>\r\n        </metadata>\r\n        <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Global_0p25deg_ana/catalog.xml\"
+        xlink:title=\"GFS Quarter Degree Analysis\" name=\"GFS Quarter Degree Analysis\"
+        harvest=\"true\">\r\n          <metadata inherited=\"true\">\r\n            <documentation
+        type=\"summary\">Analysis grids only.</documentation>\r\n          </metadata>\r\n
+        \       </catalogRef>\r\n        <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Global_0p25deg/catalog.xml\"
+        xlink:title=\"GFS Quarter Degree Forecast\" name=\"GFS Quarter Degree Forecast\"
+        harvest=\"true\">\r\n          <metadata inherited=\"true\">\r\n            <documentation
+        type=\"summary\">Forecasts grids starting from the 0 hour forecast every 3
+        hours out to 10 days, then 12 hour forecasts for days 10-16.</documentation>\r\n
+        \         </metadata>\r\n        </catalogRef>\r\n      </dataset>\r\n      <dataset
+        name=\"GFS Half Degree - Global Coverage\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP GFS Model : AWIPS 230 (G) Grid.
+        Global Lat/Lon grid. Model runs at 0, 6, 12, and 18Z. Horizontal= 361 by 720
+        points, resolution 0.5 degree, Lat/Lon projection. Vertical= 1000 to 100 hPa
+        mandatory pressure levels (10 levels); surface, height above ground, pressure
+        layers.</documentation>\r\n        </metadata>\r\n        <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Global_0p5deg_ana/catalog.xml\"
+        xlink:title=\"GFS Half Degree Analysis\" name=\"GFS Half Degree Analysis\"
+        harvest=\"true\">\r\n          <metadata inherited=\"true\">\r\n            <documentation
+        type=\"summary\">Analysis grids only.</documentation>\r\n          </metadata>\r\n
+        \       </catalogRef>\r\n        <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Global_0p5deg/catalog.xml\"
+        xlink:title=\"GFS Half Degree Forecast\" name=\"GFS Half Degree Forecast\"
+        harvest=\"true\">\r\n          <metadata inherited=\"true\">\r\n            <documentation
+        type=\"summary\">Forecasts grids starting from the 0 hour forecast every 3
+        hours out to 10 days, then 12 hour forecasts for days 10-16.</documentation>\r\n
+        \         </metadata>\r\n        </catalogRef>\r\n      </dataset>\r\n      <dataset
+        name=\"GFS One Degree - Global Coverage\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP GFS Model : AWIPS 229 (F) Grid.
+        Global Lat/Lon grid. Model runs are made at 0, 6, 12, and 18Z. Horizontal
+        = 181 by 360 points, resolution 1 degree, Lat/Lon projection. Vertical = 1000
+        to 100 hPa mandatory pressure levels (10 levels); surface, height above ground,
+        pressure layers.</documentation>\r\n        </metadata>\r\n        <catalogRef
+        xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Global_onedeg_ana/catalog.xml\"
+        xlink:title=\"GFS One Degree Analysis\" name=\"GFS One Degree Analysis\" harvest=\"true\">\r\n
+        \         <metadata inherited=\"true\">\r\n            <documentation type=\"summary\">Analysis
+        grids only.</documentation>\r\n          </metadata>\r\n        </catalogRef>\r\n
+        \       <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Global_onedeg/catalog.xml\"
+        xlink:title=\"GFS One Degree Forecast\" name=\"GFS One Degree Forecast\" harvest=\"true\">\r\n
+        \         <metadata inherited=\"true\">\r\n            <documentation type=\"summary\">Forecasts
+        grids starting from the 0 hour forecast every 3 hours out to 192 hours (8
+        days).</documentation>\r\n          </metadata>\r\n        </catalogRef>\r\n
+        \     </dataset>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Global_2p5deg/catalog.xml\"
+        xlink:title=\"GFS Global 2.5 Degree\" name=\"GFS Global 2.5 Degree\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP
+        GFS Model : AWIPS 228 (A) Grid. Global Lat/Lon grid. Model runs every 12 hours
+        from 204 to 384 hours (8 to 16 days). Horizontal= 73 by 144 points, resolution
+        2.5 degree, Lat/Lon projection. Vertical = 1000 to 100 hPa mandatory pressure
+        levels (10 levels); surface, height above ground, pressure layers.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Global_onedegree_noaaport/catalog.xml\"
+        xlink:title=\"GFS Global 1.0 Degree (NOAAPORT)\" name=\"GFS Global 1.0 Degree
+        (NOAAPORT)\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP GFS Model : AWIPS 003 (A) Grid.
+        Global Lat/Lon grid. Model runs are made at 0, 6, 12, and 18Z, with forecasts
+        every 6 hours from 0 to 240 hours (0 to 10 days). Horizontal= 181 by 360 points,
+        resolution 1.0 degree, Lat/Lon projection. Vertical = 1000 to 70 hPa mandatory
+        pressure levels (12 levels); surface, height above ground, pressure layers.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Pacific_40km/catalog.xml\"
+        xlink:title=\"GFS Pacific 40km\" name=\"GFS Pacific 40km\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP
+        GFS Model : Mercator Grid over most of the Pacific. longitude 110 W to 110
+        E. Model runs are made at 0, 6, 12, and 18Z, with analysis and forecasts every
+        6 hours out 10 days. Horizontal = 300 by 369 points, resolution 40 km, Mercator
+        projection. Vertical = 1000 to 100 hPa mandatory pressure levels (29 levels);
+        surface, height above ground, pressure layers.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Pacific_20km/catalog.xml\"
+        xlink:title=\"GFS Pacific 20km\" name=\"GFS Pacific 20km\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP
+        GFS Model : Mercator Grid over most of the Pacific; longitude 110 W to 110
+        E. Model runs are made at 0, 6, 12, and 18Z, with analysis and forecasts every
+        3 hours out to 84 hours, and every 6 hours out to 10 days. Horizontal = 600
+        by 737 points, resolution 20 km, Mercator projection. Vertical = 1000 to 100
+        hPa mandatory pressure levels (29 levels); surface, height above ground, pressure
+        layers.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Puerto_Rico_0p5deg/catalog.xml\"
+        xlink:title=\"GFS Puerto Rico Half Degree\" name=\"GFS Puerto Rico Half Degree\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">NCEP GFS Model : Puerto_Rico 0.5 degree Lat/Lon grid. Model
+        runs are made at 0, 6, 12, 18 hours out to 10 days. Horizontal = 102 by 107
+        points, resolution .5 degree, Lat/Lon projection. Vertical = 1000 to 100 hPa
+        mandatory pressure levels (29 levels); surface, height above ground, pressure
+        layers.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Puerto_Rico_0p25deg/catalog.xml\"
+        xlink:title=\"GFS Puerto Rico Quarter Degree\" name=\"GFS Puerto Rico Quarter
+        Degree\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">NCEP GFS Model : Puerto_Rico 0.25 degree Lat/Lon grid. Model
+        runs are made at 0, 6, 12, and 18Z, with analysis and forecasts every 3 hours
+        out to 84 hours, and every 6 hours out to 10 days. Horizontal = 204 by 213
+        points, resolution 0.25 degree, Lat/Lon projection. Vertical = 1000 to 100
+        hPa mandatory pressure levels (29 levels); surface, height above ground, pressure
+        layers.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/CONUS_80km/catalog.xml\"
+        xlink:title=\"GFS CONUS 80km\" name=\"GFS CONUS 80km\" harvest=\"true\">\r\n
+        \       <dataFormat>GRIB-1</dataFormat>\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP GFS Model : AWIPS 211 (Q) Grid.
+        Regional - CONUS (Lambert Conformal). Model runs are made at 0, 6, 12, and
+        18Z, with analysis and forecasts every 6 hours out 10 days. Horizontal = 93
+        by 65 points, resolution 81.27 km, LambertConformal projection. Vertical =
+        1000 to 100 hPa pressure levels (29 levels); surface, height above ground,
+        pressure layers.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/CONUS_20km/catalog.xml\"
+        xlink:title=\"GFS CONUS 20km\" name=\"GFS CONUS 20km\" harvest=\"true\">\r\n
+        \       <dataFormat>GRIB-1</dataFormat>\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP GFS Model : AWIPS 215 (Q) Grid.
+        Regional - CONUS (Lambert Conformal). Model runs are made at 0, 6, 12, and
+        18Z, with analysis and forecasts every 3 hours out to 84 hours, and every
+        6 hours out to 10 days. Horizontal = 372 by 260 points, resolution 20 km,
+        LambertConformal projection. Vertical = 1000 to 100 hPa pressure levels (29
+        levels); surface, height above ground, pressure layers.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/CONUS_95km/catalog.xml\"
+        xlink:title=\"GFS CONUS 95km\" name=\"GFS CONUS 95km\" harvest=\"true\">\r\n
+        \       <dataFormat>GRIB-2</dataFormat>\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP GFS Model : AWIPS 213 (H) Grid.
+        National - CONUS - Double Resolution (polar stereographic). Model runs are
+        made at 0, 6, 12, and 18Z, with analysis and forecasts every 6 hours out 4
+        days. Horizontal = 129 by 85 points, resolution 95.25 km, Polar Stereographic
+        projection. Vertical = 1000 to 100 hPa mandatory pressure levels (10 levels);
+        surface, height above ground, pressure layers.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/GFS/Alaska_20km/catalog.xml\"
+        xlink:title=\"GFS Alaska 20km\" name=\"GFS Alaska 20km\" harvest=\"true\">\r\n
+        \       <dataFormat>GRIB-2</dataFormat>\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP GFS Model : AWIPS 217 (H) Grid.
+        National - Alaska - Double Resolution (polar stereographic). Model runs are
+        made at 0, 6, 12, and 18Z, with analysis and forecasts every 3 hours out to
+        84 hours, and every 6 hours out to 10 days. Horizontal = 520 by 340 points,
+        resolution 20 km, Polar Stereographic projection. Vertical = 1000 to 100 hPa
+        pressure levels (29 levels); surface, height above ground, pressure layers.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n    </dataset>\r\n    <dataset
+        name=\"High Resolution Rapid Refresh (HRRR)\">\r\n      <metadata inherited=\"true\">\r\n
+        \       <serviceName>fullServices</serviceName>\r\n        <authority>edu.ucar.unidata</authority>\r\n
+        \       <dataType>GRID</dataType>\r\n        <dataFormat>GRIB-2</dataFormat>\r\n
+        \     </metadata>\r\n      <dataset name=\"HRRR from NOAA/GSD\">\r\n        <catalogRef
+        xlink:href=\"http://thredds-jumbo.unidata.ucar.edu/thredds/catalog/grib/HRRR/CONUS_3km/surface/catalog.xml\"
+        xlink:title=\"GSD HRRR CONUS 3km surface\" name=\"GSD HRRR CONUS 3km surface\"
+        />\r\n        <catalogRef xlink:href=\"http://thredds-jumbo.unidata.ucar.edu/thredds/catalog/grib/HRRR/CONUS_3km/wrfprs/catalog.xml\"
+        xlink:title=\"GSD HRRR CONUS 3km wrfprs\" name=\"GSD HRRR CONUS 3km wrfprs\"
+        />\r\n      </dataset>\r\n      <dataset name=\"HRRR from NCEP\">\r\n        <metadata
+        inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP High
+        Resolution Rapid Refresh</documentation>\r\n          <documentation xlink:href=\"http://www.nco.ncep.noaa.gov/pmb/products/hrrr/\"
+        xlink:title=\"NCEP Model Notes\" />\r\n          <documentation type=\"summary\">NCEP
+        HRRR Model : AWIPS 184 (C) Grid. 2.5 km NDFD grid over CONUS (Lambert Conformal).
+        Model runs are made hourly. Horizontal = 2145 by 1377 points, resolution 2.5
+        km, Lambert Conformal projection. Vertical = 1000 to 500 hPa mandatory pressure
+        levels (5 levels); surface, height above ground, pressure layers.</documentation>\r\n
+        \       </metadata>\r\n        <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/HRRR/CONUS_2p5km_ANA/catalog.xml\"
+        xlink:title=\"NCEP HRRR CONUS 2.5km Analysis\" name=\"NCEP HRRR CONUS 2.5km
+        Analysis\" harvest=\"true\">\r\n          <dataFormat>GRIB-2</dataFormat>\r\n
+        \         <metadata inherited=\"true\">\r\n            <documentation type=\"summary\">This
+        collection contains analysis grids only.</documentation>\r\n          </metadata>\r\n
+        \       </catalogRef>\r\n        <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/HRRR/CONUS_2p5km/catalog.xml\"
+        xlink:title=\"NCEP HRRR CONUS 2.5km\" name=\"NCEP HRRR CONUS 2.5km\" harvest=\"true\">\r\n
+        \         <dataFormat>GRIB-2</dataFormat>\r\n          <metadata inherited=\"true\">\r\n
+        \           <documentation type=\"summary\">Forecasts grids every hour out
+        15 hours.</documentation>\r\n          </metadata>\r\n        </catalogRef>\r\n
+        \     </dataset>\r\n    </dataset>\r\n    <dataset name=\"North American Model
+        (NAM)\">\r\n      <metadata inherited=\"true\">\r\n        <documentation
+        type=\"summary\">NCEP Nonhydrostatic Mesoscale Model (NMM) and Gridpoint Statistical
+        Interpolation (GSI) analysis, running in the Weather Research and Forecasting
+        (WRF) infrastructure.</documentation>\r\n        <documentation xlink:href=\"http://meted.ucar.edu/nwp/pcu2/NAMWRFjun2006.htm\"
+        xlink:title=\"COMET MetEd (Meteorology Education and Training) documentation\"
+        />\r\n        <documentation xlink:href=\"http://www.nco.ncep.noaa.gov/pmb/products/nam/\"
+        xlink:title=\"NCEP NAM product inventory\" />\r\n      </metadata>\r\n      <catalogRef
+        xlink:href=\"/thredds/catalog/grib/NCEP/NAM/Alaska_11km/catalog.xml\" xlink:title=\"NAM
+        Alaska 11km\" name=\"NAM Alaska 11km\" harvest=\"true\">\r\n        <metadata
+        inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP North
+        American Model: AWIPS 242 (S) Grid over Alaska. Model runs are made at 0,
+        6, 12, 18Z with analysis and forecasts every 3 hours out to 84 hours (3.5
+        days). Horizontal = 553 by 425 points, resolution 11.25 km, Polar Stereographic
+        projection. Vertical = 1000 to 100 hPa pressure levels.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/Alaska_45km/noaaport/catalog.xml\"
+        xlink:title=\"NAM Alaska 45km from NOAAPORT\" name=\"NAM Alaska 45km from
+        NOAAPORT\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <dataFormat>GRIB-1</dataFormat>\r\n          <documentation type=\"summary\">NCEP
+        North American Model : AWIPS 216 (V) grid over Alaska. Model runs are made
+        at 0 and 12Z, with analysis and forecasts every 3 hours out to 60 hours. Horizontal
+        = 139 by 107 points, resolution 45.0 km, Polar Stereographic projection. Vertical
+        = 1000 to 50 hPa pressure levels.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/Alaska_45km/conduit/catalog.xml\"
+        xlink:title=\"NAM Alaska 45km from CONDUIT\" name=\"NAM Alaska 45km from CONDUIT\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">NCEP North American Model : AWIPS 216 (V) grid over Alaska.
+        Model runs are made at 00Z, 06Z, 12Z, and 18Z with analysis and forecasts
+        every 3 hours out to 84 hours (3.5 days). Horizontal = 139 by 107 points,
+        resolution 45.0 km, Polar Stereographic projection. Vertical = 1000 to 50
+        hPa pressure levels.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/Alaska_95km/catalog.xml\"
+        xlink:title=\"NAM Alaska 95km\" name=\"NAM Alaska 95km\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <dataFormat>GRIB-1</dataFormat>\r\n
+        \         <documentation type=\"summary\">NCEP North American Model : AWIPS
+        207 (N) Regional - Alaska. Model runs are made at 0 and 12Z, with analysis
+        and forecasts every 6 hours out to 60 hours. Horizontal = 49 by 35 points,
+        resolution 95.25 km, Stereographic projection. Vertical = 1000 to 100 hPa
+        pressure levels.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_12km/catalog.xml\"
+        xlink:title=\"NAM CONUS 12km from NOAAPORT\" name=\"NAM CONUS 12km from NOAAPORT\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">NCEP North American Model : AWIPS 218 (B) grid over the continental
+        United States. Model runs are made at 06Z, 12Z, 18Z and 00Z, with analysis
+        and forecasts every 3 hours out to 84 hours (3.5 days). Horizontal = 614 by
+        428 points, resolution 12.19 km, LambertConformal projection. Vertical = 1000
+        to 100 hPa pressure levels (29).</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_12km/conduit/catalog.xml\"
+        xlink:title=\"NAM CONUS 12km from CONDUIT\" name=\"NAM CONUS 12km from CONDUIT\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">NCEP North American Model : AWIPS 218 (B) grid over the continental
+        United States. Model runs are made at 06Z, 12Z, 18Z and 00Z, with analysis
+        and forecasts every hour, out to 36 hours, and then every three hours out
+        to 84 hours (3.5 days). Horizontal = 614 by 428 points, resolution 12.19 km,
+        LambertConformal projection. Vertical = small number of mandatory pressure
+        levels, lots of surface fields.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_20km/noaaport/catalog.xml\"
+        xlink:title=\"NAM CONUS 20km\" name=\"NAM CONUS 20km\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <dataFormat>GRIB-1</dataFormat>\r\n
+        \         <documentation type=\"summary\">Model runs are made at 00Z, and
+        12Z with analysis and forecasts every 3 hours out to 60 hours; and at 06Z,
+        and 18Z with analysis and forecasts every 3 hours out to 48 hours. Vertical
+        = surface, height above ground, and 1000 to 30 hPa pressure levels.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_40km/conduit/catalog.xml\"
+        xlink:title=\"NAM CONUS 40km\" name=\"NAM CONUS 40km\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP
+        North American Model : AWIPS 212 (R) Regional - CONUS - Double Resolution.
+        Horizontal = 185 by 129 points, resolution 40.63 km; LambertConformal projection.
+        Vertical = surface, 1000 to 50 hPa pressure levels, layers, and depth. Model
+        runs are made at 00Z, 06Z, 12Z, and 18Z and have analysis and forecasts every
+        3 hours out to 84 hours.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/CONUS_80km/catalog.xml\"
+        xlink:title=\"NAM CONUS 80km\" name=\"NAM CONUS 80km\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <dataFormat>GRIB-1</dataFormat>\r\n
+        \         <documentation type=\"summary\">NCEP North American Model : AWIPS
+        211 (Q) Regional - CONUS (Lambert Conformal). Model runs are made at 12Z and
+        00Z, with analysis and forecasts every 6 hours out to 60 hours. Horizontal
+        = 93 by 65 points, resolution 81.27 km, LambertConformal projection. Vertical
+        = 1000 to 100 hPa pressure levels.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/Polar_90km/catalog.xml\"
+        xlink:title=\"NAM Polar 90km\" name=\"NAM Polar 90km\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP
+        North American Model : AWIPS 105 Grid. Model runs are made at 0, 6, 12, and
+        18Z, with analysis and forecasts every 3 hours out to 84 hours. Horizontal
+        = 147 by 110 points, resolution 90.75 km, Polar Stereographic projection.
+        Vertical = 1000 to 50 hPa pressure levels.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/NAM/Firewxnest/catalog.xml\"
+        xlink:title=\"NAM Fireweather Nested\" name=\"NAM Fireweather Nested\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">The
+        FWIS runs are high resolution innermost nests of the new NAM that are placeable
+        within either the 4 km CONUS or 6 km Alaska nests that run each cycle at 00z,
+        06z, 12z and 18z, with forecasts to 36 hours. If it is placed inside the CONUS,
+        then it runs with a 1.33 km horizontal spacing using a 375x375x60 grid. If
+        it is placed inside Alaska, then it runs with a 1.5 km horizontal spacing
+        using a 333x333x60 grid. FWIS runs on a rotated lat-long grid and uses a B-grid
+        stagger of variables. The vertical coordinate and resolution are identical
+        to NAM and its nests \u2013 i.e. sigma-pressure hybrid with a top at 2 mb.
+        For FWIS inside CONUS, all output fields are mapped to a 1.27 km Lambert conic
+        conformal grid whose size varies to encompass as completely as possible the
+        FWIS computational domain. For FWIS inside Alaska, all output fields are mapped
+        to a 1.48825 km polar-stereographic grid whose size varies to encompass as
+        completely as possible the FWIS computational domain.</documentation>\r\n
+        \         <documentation xlink:href=\"http://www.emc.ncep.noaa.gov/mmb/mmbpll/firewx/\"
+        xlink:title=\"NCEP NAM Fire weather product inventory\" />\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n    </dataset>\r\n    <dataset name=\"Rapid Refresh
+        (RAP)\">\r\n      <metadata inherited=\"true\">\r\n        <documentation
+        type=\"summary\">NCEP Rapid Refresh (RR / RAP)) Model: frequently updated
+        short-range weather forecasts. Replaced the Rapid Update Cycle (RUC/RUC2)
+        on 05 May 2012 12Z. Model runs are made hourly, with analysis and hourly forecasts
+        out to 3 hours; on the 0, 3, 6, 9, 12, 15, 18, and 21Z runs, the hourly forecasts
+        go out to 12 hours</documentation>\r\n        <documentation xlink:href=\"http://rapidrefresh.noaa.gov/\"
+        xlink:title=\"Earth System Research Laboratory (ESRL)\" />\r\n      </metadata>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/RAP/CONUS_13km/catalog.xml\"
+        xlink:title=\"Rapid Refresh CONUS 13km\" name=\"Rapid Refresh CONUS 13km\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">Horizontal = 337 by 451 points, resolution 13.55 km, LambertConformal
+        projection.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/RAP/CONUS_20km/catalog.xml\"
+        xlink:title=\"Rapid Refresh CONUS 20km\" name=\"Rapid Refresh CONUS 20km\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">Horizontal = 301 by 225 points, resolution 20.31 km, Lambert
+        Conformal projection.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/RAP/CONUS_40km/catalog.xml\"
+        xlink:title=\"Rapid Refresh CONUS 40km\" name=\"Rapid Refresh CONUS 40km\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <dataFormat>GRIB-2</dataFormat>\r\n
+        \         <documentation type=\"summary\">Horizontal = 151 by 113 points,
+        resolution 40.63 km, LambertConformal projection.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n    </dataset>\r\n    <dataset name=\"Short Range Ensemble
+        Forecasting (SREF)\">\r\n      <metadata inherited=\"true\">\r\n        <documentation
+        type=\"summary\">NCEP Short Range Ensemble Forecast (SREF)</documentation>\r\n
+        \       <documentation xlink:href=\"http://w1.spc.woc.noaa.gov/exper/sref/\"
+        xlink:title=\"NCEP/SREF Website\" />\r\n      </metadata>\r\n      <catalogRef
+        xlink:href=\"/thredds/catalog/grib/NCEP/SREF/CONUS_40km/ensprod/catalog.xml\"
+        xlink:title=\"SREF CONUS 40km Ensemble Derived Products\" name=\"SREF CONUS
+        40km Ensemble Derived Products\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP Short Range Ensemble Forecast
+        (SREF) 40km derived products: mean, spread, and probability, over CONUS with
+        185 by 129 points, resolution 40 km. Models are run daily at 3,9,15,and 21Z.
+        Forecasts every 3 hours from 3 to 87 hours.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/SREF/CONUS_40km/ensprod_biasc/catalog.xml\"
+        xlink:title=\"SREF CONUS 40km Ensemble Derived Products (Bias Corrected)\"
+        name=\"SREF CONUS 40km Ensemble Derived Products (Bias Corrected)\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP
+        Short Range Ensemble Forecast (SREF) 40km derived products: bias-corrected
+        mean, spread, and probability, over CONUS with 185 by 129 points, resolution
+        40 km. Models are run daily at 3,9,15,and 21Z. Forecasts every 3 hours from
+        3 to 87 hours.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/SREF/Alaska_45km/ensprod/catalog.xml\"
+        xlink:title=\"SREF Alaska 45km Ensemble Derived Products\" name=\"SREF Alaska
+        45km Ensemble Derived Products\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">NCEP SREF Alaska 45km derived products:mean,
+        spread, and probability.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/SREF/PacificNE_0p4/ensprod/catalog.xml\"
+        xlink:title=\"SREF Pacific North East 0.4 Degree Ensemble Derived Products\"
+        name=\"SREF Pacific North East 0.4 Degree Ensemble Derived Products\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">NCEP
+        SREF Pacific NE 0.4 degree derived products:mean, spread, and probability.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n    </dataset>\r\n    <dataset
+        name=\"Wave Watch III (WW3)\">\r\n      <metadata inherited=\"true\">\r\n
+        \       <documentation type=\"summary\">NCEP Wave Watch III (WW3): US National
+        Weather Service gridded forecasts of sensible weather elements.</documentation>\r\n
+        \       <documentation xlink:href=\"http://polar.ncep.noaa.gov/waves/products.shtml\"
+        xlink:title=\"NWS/WW3 Website\" />\r\n      </metadata>\r\n      <catalogRef
+        xlink:href=\"/thredds/catalog/grib/NCEP/WW3/Global/catalog.xml\" xlink:title=\"Wave
+        Watch III Global\" name=\"Wave Watch III Global\" harvest=\"true\">\r\n        <metadata
+        inherited=\"true\">\r\n          <documentation type=\"summary\">720 by 336
+        points, resolution 30 minute. Models are run daily at 0Z, 6Z, 12Z and 18Z.
+        Forecasts every 3 hours from 0 to 72, every 6 hours from 72 to 180 hours.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/WW3/Regional_Alaska/catalog.xml\"
+        xlink:title=\"Wave Watch III Regional Alaska\" name=\"Wave Watch III Regional
+        Alaska\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">401 by 187 points, resolution 10 minute. Models are run daily
+        at 0Z, 6Z, 12Z and 18Z. Forecasts every 3 hours from 0 to 72, every 6 hours
+        from 72 to 180 hours.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/WW3/Coastal_Alaska/catalog.xml\"
+        xlink:title=\"Wave Watch III Coastal Alaska\" name=\"Wave Watch III Coastal
+        Alaska\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">548 by 391 points, resolution 4 minute. Models are run daily
+        at 0Z, 6Z, 12Z and 18Z. Forecasts every 3 hours from 0 to 72, every 6 hours
+        from 72 to 180 hours.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/WW3/Regional_Eastern_Pacific/catalog.xml\"
+        xlink:title=\"Wave Watch III Regional Eastern Pacific\" name=\"Wave Watch
+        III Regional Eastern Pacific\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">511 by 301 points, resolution 10
+        minute. Models are run daily at 0Z, 6Z, 12Z and 18Z. Forecasts every 3 hours
+        from 0 to 72, every 6 hours from 72 to 180 hours.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/WW3/Regional_US_East_Coast/catalog.xml\"
+        xlink:title=\"Wave Watch III Regional US East Coast\" name=\"Wave Watch III
+        Regional US East Coast\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">301 by 331 points, resolution 10
+        minute. Models are run daily at 0Z, 6Z, 12Z and 18Z. Forecasts every 3 hours
+        from 0 to 72, every 6 hours from 72 to 180 hours.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/WW3/Regional_US_West_Coast/catalog.xml\"
+        xlink:title=\"Wave Watch III Regional US West Coast\" name=\"Wave Watch III
+        Regional US West Coast\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">241 by 151 points, resolution 10
+        minute. Models are run daily at 0Z, 6Z, 12Z and 18Z. Forecasts every 3 hours
+        from 0 to 72, every 6 hours from 72 to 180 hours.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/WW3/Coastal_US_East_Coast/catalog.xml\"
+        xlink:title=\"Wave Watch III Coastal US East Coast\" name=\"Wave Watch III
+        Coastal US East Coast\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">586 by 481 points, resolution 4
+        minute. Models are run daily at 0Z, 6Z, 12Z and 18Z. Forecasts every 3 hours
+        from 0 to 72, every 6 hours from 72 to 180 hours.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/NCEP/WW3/Coastal_US_West_Coast/catalog.xml\"
+        xlink:title=\"Wave Watch III Coastal US West Coast\" name=\"Wave Watch III
+        Coastal US West Coast\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">736 by 526 points, resolution 4
+        minute. Models are run daily at 0Z, 6Z, 12Z and 18Z. Forecasts every 3 hours
+        from 0 to 72, every 6 hours from 72 to 180 hours.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n    </dataset>\r\n  </dataset>\r\n  <dataset name=\"FNMOC
+        Forecast Models\">\r\n    <metadata inherited=\"true\">\r\n      <serviceName>fullServices</serviceName>\r\n
+        \     <authority>edu.ucar.unidata</authority>\r\n      <dataType>Grid</dataType>\r\n
+        \     <dataFormat>GRIB-1</dataFormat>\r\n      <documentation xlink:href=\"http://www.usno.navy.mil/FNMOC/\"
+        xlink:title=\"FNMOC Home page\" />\r\n      <documentation type=\"rights\">Freely
+        available</documentation>\r\n      <documentation type=\"processing_level\">Transmitted
+        through Unidata Internet Data Distribution.</documentation>\r\n      <documentation
+        type=\"processing_level\">Read by CDM Grib Collection.</documentation>\r\n
+        \     <creator>\r\n        <name vocabulary=\"DIF\">Fleet Numerical Meteorology
+        and Oceanography Center(FNMOC)</name>\r\n        <contact url=\"http://gcmd.nasa.gov/Aboutus/software_docs/help_guide.html\"
+        email=\"http://gcmd.nasa.gov/MailComments/MailComments.jsf?rcpt=gcmduso\"
+        />\r\n      </creator>\r\n      <publisher>\r\n        <name vocabulary=\"ADN\">University
+        Corporation for Atmospheric Research (UCAR)/Unidata</name>\r\n        <contact
+        url=\"http://www.unidata.ucar.edu/\" email=\"support@unidata.ucar.edu\" />\r\n
+        \     </publisher>\r\n      <timeCoverage>\r\n        <end>present</end>\r\n
+        \       <duration>45 days</duration>\r\n      </timeCoverage>\r\n    </metadata>\r\n
+        \   <dataset name=\"NAVy Global Environmental Model (NAVGEM) Model\">\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/FNMOC/NAVGEM/Global_0p5deg/catalog.xml\"
+        xlink:title=\"FNMOC NAVGEM Global 0.5 Degree\" name=\"FNMOC NAVGEM Global
+        0.5 Degree\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">FNMOC NAVGEM Global_0p5deg Model
+        : Global Lat/Lon grid. Model runs are made at 0, 6, 12, and 18Z, with analysis
+        and forecasts every 3 hours out 66 hours. Horizontal = 361 by 720 points,
+        resolution 0.5 degree, Lat/Lon projection. Vertical = 1013 to 4 hPa pressure
+        levels (33 levels); surface, height above ground, pressure layers.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n    </dataset>\r\n    <dataset
+        name=\"Wave Watch 3 (WW3) Model\">\r\n      <metadata inherited=\"true\">\r\n
+        \       <documentation xlink:href=\"https://www.fnmoc.navy.mil/ww3_cgi/index.html\"
+        xlink:title=\"FNMOC WW3 documentation\" />\r\n      </metadata>\r\n      <catalogRef
+        xlink:href=\"/thredds/catalog/grib/FNMOC/WW3/Global_1p0deg/catalog.xml\" xlink:title=\"FNMOC
+        WW3 Global 1.0 Degree\" name=\"FNMOC WW3 Global 1.0 Degree\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">FNMOC
+        WW3 Global_1p0deg Model : Global Lat/Lon grid. Model runs are made at 0, and
+        12Z, with analysis and forecasts every 3 hours out 24 hours then every 6 hours
+        out 180 hours. Horizontal= 181 by 360 points, resolution 1 degree, Lat/Lon
+        projection.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/FNMOC/WW3/Europe/catalog.xml\"
+        xlink:title=\"FNMOC WW3 Europe\" name=\"FNMOC WW3 Europe\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">FNMOC
+        WW3 Europe Model : Global Lat/Lon grid. Model runs are made at 0, and 12Z,
+        with analysis and forecasts every 6 hours out 72 hours. Horizontal= 188 by
+        301 points, resolution .2 degree, Lat/Lon projection.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n    </dataset>\r\n    <dataset
+        name=\"Forecast of Aerosol Radiative Optical Properties (FAROP) Model\">\r\n
+        \     <metadata inherited=\"true\">\r\n        <documentation xlink:href=\"http://www.bsc.es/wmo/files/Westphal_presentation.pdf\"
+        xlink:title=\"FAROP documentation(pdf)\" />\r\n      </metadata>\r\n      <catalogRef
+        xlink:href=\"/thredds/catalog/grib/FNMOC/FAROP/Global_1p0deg/catalog.xml\"
+        xlink:title=\"FNMOC FAROP Global 1.0 Degree\" name=\"FNMOC FAROP Global 1.0
+        Degree\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">FNMOC FAROP Global_1p0deg Model : Global Lat/Lon grid. Model
+        runs are made at 0, 6, 12, and 18Z, with analysis and forecasts every 3 hours
+        out 9 hours. Horizontal= 181 by 360 points, resolution 1 degree, Lat/Lon projection.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n    </dataset>\r\n    <dataset
+        name=\"Coupled Ocean / Atmosphere Mesoscale Prediction System (COAMPS) Model\">\r\n
+        \     <metadata inherited=\"true\">\r\n        <documentation xlink:href=\"http://www.nrlmry.navy.mil/coamps-web/web/home\"
+        xlink:title=\"COAMPS home page\" />\r\n        <documentation xlink:href=\"http://gcmd.nasa.gov/records/COAMPS.html\"
+        xlink:title=\"GCMD Notes\" />\r\n      </metadata>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/FNMOC/COAMPS/Western_Atlantic/catalog.xml\"
+        xlink:title=\"FNMOC COAMPS Western Atlantic\" name=\"FNMOC COAMPS Western
+        Atlantic\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">FNMOC COAMPS Western Atlantic Model
+        : Global Lat/Lon grid. Model runs are made at 0 and 12Z, with analysis and
+        forecasts every 3 hours out 72 hours. Horizontal= 176 by 191 points, resolution
+        .2 degree, Lat/Lon projection.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/FNMOC/COAMPS/Europe/catalog.xml\"
+        xlink:title=\"FNMOC COAMPS Europe\" name=\"FNMOC COAMPS Europe\" harvest=\"true\">\r\n
+        \       <metadata inherited=\"true\">\r\n          <documentation type=\"summary\">FNMOC
+        COAMPS Europe Model : Global Lat/Lon grid. Model runs are made at 0 and 12Z,
+        with analysis and forecasts every 6 hours out 96 hours. Horizontal= 186 by
+        301 points, resolution .2 degree, Lat/Lon projection.</documentation>\r\n
+        \       </metadata>\r\n      </catalogRef>\r\n      <catalogRef xlink:href=\"/thredds/catalog/grib/FNMOC/COAMPS/Equatorial_America/catalog.xml\"
+        xlink:title=\"FNMOC COAMPS Equatorial America\" name=\"FNMOC COAMPS Equatorial
+        America\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">FNMOC COAMPS Equatorial America Model : Global Lat/Lon grid.
+        Model runs are made at 0 and 12Z, with analysis and forecasts every 3 hours
+        out 48 hours. Horizontal= 298 by 461 points, resolution 0.15 degree, Lat/Lon
+        projection.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/FNMOC/COAMPS/Northeast_Pacific/catalog.xml\"
+        xlink:title=\"FNMOC COAMPS Northeast Pacific\" name=\"FNMOC COAMPS Northeast
+        Pacific\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">FNMOC COAMPS Northeastern Pacific Model : Global Lat/Lon
+        grid. Model runs are made at 0 and 12Z, with analysis and forecasts every
+        3 hours out 48 hours. Horizontal= 156 by 271 points, resolution .2 degree,
+        Lat/Lon projection.</documentation>\r\n        </metadata>\r\n      </catalogRef>\r\n
+        \     <catalogRef xlink:href=\"/thredds/catalog/grib/FNMOC/COAMPS/Southern_California/catalog.xml\"
+        xlink:title=\"FNMOC COAMPS Southern California\" name=\"FNMOC COAMPS Southern
+        California\" harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n
+        \         <documentation type=\"summary\">FNMOC COAMPS Southern California
+        Model : Global Lat/Lon grid. Model runs are made at 0 and 12Z, with analysis
+        and forecasts every 3 hours out 48 hours. Horizontal= 141 by 128 points, resolution
+        .15 degree, Lat/Lon projection.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n    </dataset>\r\n    <dataset name=\"Navy Coupled
+        Ocean Data Assimilation (NCODA) Model\">\r\n      <metadata inherited=\"true\">\r\n
+        \       <documentation xlink:href=\"http://coastalmodeling.rsmas.miami.edu/Application/View/21/MQ==\"
+        xlink:title=\"NCODA documentation\" />\r\n      </metadata>\r\n      <catalogRef
+        xlink:href=\"/thredds/catalog/grib/FNMOC/NCODA/Global_Ocean/catalog.xml\"
+        xlink:title=\"FNMOC NCODA Global Ocean\" name=\"FNMOC NCODA Global Ocean\"
+        harvest=\"true\">\r\n        <metadata inherited=\"true\">\r\n          <documentation
+        type=\"summary\">FNMOC NCODA Model : Global Lat/Lon grid. Model runs are made
+        at 12Z, with analysis and forecasts at 0Z. Horizontal= 721 by 1440 points,
+        resolution .25 degree, Lat/Lon projection.</documentation>\r\n        </metadata>\r\n
+        \     </catalogRef>\r\n    </dataset>\r\n  </dataset>\r\n</catalog>\r\n"}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [Keep-Alive]
+      Content-Language: [en-US]
+      Content-Type: [application/xml;charset=UTF-8]
+      Date: ['Wed, 01 Nov 2017 03:51:55 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache/2.4.27 (Unix) OpenSSL/1.0.1e-fips mod_jk/1.2.42]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: '200'}
+version: 1

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -262,3 +262,10 @@ def test_ramadda_access_urls():
                                          'synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c'
                                          '2VzRUNPQS9keW5hbW9fYmFzaWNfdjJiXzIwMTFhbGwubmM='
                                          '/entry.das')
+
+
+@recorder.use_cassette('tds50_catalogref_follow')
+def test_tds50_catalogref_follow():
+    """Test following a catalog ref url on TDS 5."""
+    cat = TDSCatalog('http://thredds-test.unidata.ucar.edu/thredds/catalog.xml')
+    assert len(cat.catalog_refs[0].follow().catalog_refs) == 59

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -246,3 +246,19 @@ def test_ramadda_catalog():
     url = 'http://weather.rsmas.miami.edu/repository?output=thredds.catalog'
     cat = TDSCatalog(url)
     assert len(cat.catalog_refs) == 12
+
+
+@recorder.use_cassette('rsmas_ramadda_datasets')
+def test_ramadda_access_urls():
+    """Test creating access urls from a catalog from RAMADDA."""
+    url = 'http://weather.rsmas.miami.edu/repository?output=thredds.catalog'
+
+    # Walk down a few levels to where we can get a dataset
+    cat = (TDSCatalog(url).catalog_refs[0].follow().catalog_refs[0].follow()
+                          .catalog_refs[0].follow())
+
+    ds = cat.datasets[3]
+    assert ds.access_urls['opendap'] == ('http://weather.rsmas.miami.edu/repository/opendap/'
+                                         'synth:a43c1cc4-1cf2-4365-97b9-6768b8201407:L3YyYl91c'
+                                         '2VzRUNPQS9keW5hbW9fYmFzaWNfdjJiXzIwMTFhbGwubmM='
+                                         '/entry.das')

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -238,3 +238,11 @@ def test_simple_service_within_compound():
     assert (cat.datasets[0].access_urls ==
             {'HTTPServer': 'http://thredds-test.unidata.ucar.edu/thredds/fileServer/noaaport/'
                            'text/tropical/atlantic/hdob/High_density_obs_20170824.txt'})
+
+
+@recorder.use_cassette('rsmas_ramadda')
+def test_ramadda_catalog():
+    """Test parsing a catalog from RAMADDA."""
+    url = 'http://weather.rsmas.miami.edu/repository?output=thredds.catalog'
+    cat = TDSCatalog(url)
+    assert len(cat.catalog_refs) == 12

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -5,7 +5,6 @@
 
 from datetime import datetime
 import logging
-import warnings
 
 import pytest
 
@@ -98,14 +97,12 @@ def test_simple_point_feature_collection_xml():
 
 
 @recorder.use_cassette('html_then_xml_catalog')
-def test_html_link():
+def test_html_link(recwarn):
     """Test that we fall-back when given an HTML catalog page."""
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
-               'grib/NCEP/RAP/CONUS_13km/catalog.html')
-        cat = TDSCatalog(url)
-        assert cat
+    url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/'
+           'grib/NCEP/RAP/CONUS_13km/catalog.html')
+    TDSCatalog(url)
+    assert 'Changing' in str(recwarn.pop(UserWarning).message)
 
 
 @recorder.use_cassette('follow_cat')


### PR DESCRIPTION
- Handle RAMADDA TDS catalogs by allowing for no name attribute on catalog refs (just use title)
- Fix generating access URLs for RAMADDA (which uses a full URL for services) by properly using `urljoin`
- Fix catalog reference URL generation on TDS 5 by making sure we use the url from the response as the actual catalog URL (handles forwards)