### PR TITLE
MNT: Fix some import lint

### DIFF
--- a/examples/upperair/Wyoming_Request.py
+++ b/examples/upperair/Wyoming_Request.py
@@ -9,8 +9,8 @@ This example shows how to use siphon's `simplewebswervice` support to create a q
 the Wyoming upper air archive.
 """
 
-
 from datetime import datetime
+
 from siphon.simplewebservice.wyoming import WyomingUpperAir
 
 ####################################################

--- a/siphon/simplewebservice/wyoming.py
+++ b/siphon/simplewebservice/wyoming.py
@@ -9,6 +9,7 @@ import warnings
 from bs4 import BeautifulSoup
 import numpy as np
 import pandas as pd
+
 from .._tools import get_wind_components
 from ..http_util import HTTPEndPoint
 


### PR DESCRIPTION
flake8-import-order 0.15 stopped silencing some messages, so now we see
a few inconsistencies in our formatting. Fix them.