### PR TITLE
Adding function to read in IGRA2 upper air data

### DIFF
--- a/examples/upperair/IGRA2_Request.py
+++ b/examples/upperair/IGRA2_Request.py
@@ -5,8 +5,8 @@
 IGRA2 Upper Air Data Request
 ==============================
 
-This example shows how to use siphon's `simplewebswervice` support to create a query to
-the Integrated Global Radiosonde Archive version 2.
+This example shows how to use siphon's `simplewebswervice` support to create a
+query to the Integrated Global Radiosonde Archive version 2.
 """
 
 from datetime import datetime
@@ -36,8 +36,8 @@ print(df['pressure'])
 print(header['latitude'])
 
 ####################################################
-# Units are stored in a dictionary with the variable name as the key in the `units` attribute
-# of the dataframe.
+# Units are stored in a dictionary with the variable name as the key in the `units`
+# attribute of the dataframe.
 print(df.units)
 print(header.units)
 

--- a/examples/upperair/IGRA2_Request.py
+++ b/examples/upperair/IGRA2_Request.py
@@ -26,6 +26,8 @@ df, header = IGRAUpperAir.request_data(date, station)
 ####################################################
 # Inspect data columns in the dataframe.
 print(df.columns)
+
+# Inspect metadata from the data headers
 print(header.columns)
 
 ####################################################
@@ -47,6 +49,9 @@ print(df.units['pressure'])
 date = [datetime(2014, 9, 10, 0), datetime(2015, 9, 10, 12)]
 station = 'USM00070026'
 df, header = IGRAUpperAir.request_data(date, station)
+
+print(df.head())
+print(header.head())
 
 ####################################################
 # IGRA2-Derived data can be accessed using the keyword derived=True.

--- a/examples/upperair/IGRA2_Request.py
+++ b/examples/upperair/IGRA2_Request.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2018 University Corporation for Atmospheric Research/Unidata.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""
+IGRA2 Upper Air Data Request
+==============================
+
+This example shows how to use siphon's `simplewebswervice` support to create a query to
+the Integrated Global Radiosonde Archive version 2.
+"""
+
+from datetime import datetime
+
+from siphon.simplewebservice.igra2 import IGRAUpperAir
+
+####################################################
+# Create a datetime object for the sounding and string of the station identifier.
+date = datetime(2014, 9, 10, 0)
+station = 'USM00070026'
+
+####################################################
+# Make the request. IGRAUpperAir returns a dataframe containing the sounding data and
+# a dataframe with station metadata from the sounding header.
+df, header = IGRAUpperAir.request_data(date, station)
+
+####################################################
+# Inspect data columns in the dataframe.
+print(df.columns)
+print(header.columns)
+
+####################################################
+# Pull out a specific column of data.
+print(df['pressure'])
+print(header['latitude'])
+
+####################################################
+# Units are stored in a dictionary with the variable name as the key in the `units` attribute
+# of the dataframe.
+print(df.units)
+print(header.units)
+
+####################################################
+print(df.units['pressure'])
+
+####################################################
+# Multiple records can be extracted simultaneously:
+date = [datetime(2014, 9, 10, 0), datetime(2015, 9, 10, 12)]
+station = 'USM00070026'
+df, header = IGRAUpperAir.request_data(date, station)
+
+####################################################
+# IGRA2-Derived data can be accessed using the keyword derived=True.
+# This data has much more information in the headers.
+df, header = IGRAUpperAir.request_data(date, station, derived=True)
+
+####################################################
+# Inspect data columns in the dataframe.
+print(df.columns)
+print(header.columns)

--- a/examples/upperair/README.txt
+++ b/examples/upperair/README.txt
@@ -3,4 +3,4 @@
 Upper Air
 ---------
 
-Examples of requesting upper air (balloon) data from the Wyoming data service.
+Examples of requesting upper air (balloon) data from the Wyoming data service and from the Integrated Global Radiosonde Archive.

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -4,16 +4,16 @@
 """Read upper air data from the Integrated Global Radiosonde Archive version 2."""
 
 import datetime
-import itertools
 from io import BytesIO
 from io import StringIO
-from urllib.request import urlopen
-from zipfile import ZipFile
+import itertools
 import sys
+from urllib.request import urlopen
 import warnings
+from zipfile import ZipFile
+
 import numpy as np
 import pandas as pd
-
 
 from .._tools import get_wind_components
 
@@ -354,28 +354,27 @@ class IGRAUpperAir:
         """Format the dataframe, remove empty rows, and add units attribute."""
 
         if self.suffix == '-drvd.txt':
-
-            df.units = {'pressure': 'hPa',
-                        'reported_height': 'm',
-                        'calculated_height': 'm',
-                        'temperature': 'K',
-                        'temperature_gradient': 'K/km',
-                        'potential_temperature': 'K',
-                        'potential_temperature_gradient': 'K/km',
-                        'virtual_temperature': 'K',
-                        'virtual_potential_temperature': 'K',
-                        'vapor_pressure': 'Pa',
-                        'saturation_vapor_pressure': 'Pa',
-                        'reported_relative_humidity': '%',
-                        'calculated_relative_humidity': '%',
-                        'u_wind': 'm/s',
-                        'u_wind_gradient': '(m/s) / km)',
-                        'v_wind': 'meter/second',
-                        'v_wind_gradient': '(m/s) / km)',
-                        'refractive_index': 'unitless'}
-
             df = df.dropna(subset=('temperature', 'reported_relative_humidity',
                                    'u_wind', 'v_wind'), how='all').reset_index(drop=True)
+
+            df.units = {'pressure': 'hPa',
+                        'reported_height': 'meter',
+                        'calculated_height': 'meter',
+                        'temperature': 'Kelvin',
+                        'temperature_gradient': 'Kelvin / kilometer',
+                        'potential_temperature': 'Kelvin',
+                        'potential_temperature_gradient': 'Kelvin / kilometer',
+                        'virtual_temperature': 'Kelvin',
+                        'virtual_potential_temperature': 'Kelvin',
+                        'vapor_pressure': 'Pascal',
+                        'saturation_vapor_pressure': 'Pascal',
+                        'reported_relative_humidity': 'percent',
+                        'calculated_relative_humidity': 'percent',
+                        'u_wind': 'meter / second',
+                        'u_wind_gradient': '(meter / second) / kilometer)',
+                        'v_wind': 'meter / second',
+                        'v_wind_gradient': '(meter / second) / kilometer)',
+                        'refractive_index': 'unitless'}
 
         else:
             df['u_wind'], df['v_wind'] = get_wind_components(df['speed'],
@@ -388,45 +387,45 @@ class IGRAUpperAir:
             df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
                                    'u_wind', 'v_wind'), how='all').reset_index(drop=True)
 
-            df.units = {'etime': 's',
+            df.units = {'etime': 'second',
                         'pressure': 'hPa',
-                        'height': 'm',
+                        'height': 'meter',
                         'temperature': 'degC',
                         'dewpoint': 'degC',
                         'direction': 'degrees',
-                        'speed': 'm/s',
-                        'u_wind': 'm/s',
-                        'v_wind': 'm/s'}
+                        'speed': 'meter / second',
+                        'u_wind': 'meter / second',
+                        'v_wind': 'meter / second'}
 
         return df
 
     def _clean_header_df(self, df):
         """Format the header dataframe and add units"""
         if self.suffix == '-drvd.txt':
-            df.units = {'release_time': 's',
-                        'precipitable_water': 'mm',
+            df.units = {'release_time': 'second',
+                        'precipitable_water': 'millimeter',
                         'inv_pressure': 'hPa',
-                        'inv_height': 'm',
-                        'inv_strength': 'K',
+                        'inv_height': 'meter',
+                        'inv_strength': 'Kelvin',
                         'mixed_layer_pressure': 'hPa',
-                        'mixed_layer_height': 'm',
+                        'mixed_layer_height': 'meter',
                         'freezing_point_pressure': 'hPa',
-                        'freezing_point_height': 'm',
+                        'freezing_point_height': 'meter',
                         'lcl_pressure': 'hPa',
-                        'lcl_height': 'm',
+                        'lcl_height': 'meter',
                         'lfc_pressure': 'hPa',
-                        'lfc_height': 'm',
+                        'lfc_height': 'meter',
                         'lnb_pressure': 'hPa',
-                        'lnb_height': 'm',
+                        'lnb_height': 'meter',
                         'lifted_index': 'degC',
                         'showalter_index': 'degC',
                         'k_index': 'degC',
                         'total_totals_index': 'degC',
-                        'cape': 'J/kg',
-                        'convective_inhibition': 'J/kg'}
+                        'cape': 'Joule / kilogram',
+                        'convective_inhibition': 'Joule / kilogram'}
 
         else:
-            df.units = {'release_time': 's',
+            df.units = {'release_time': 'second',
                         'latitude': 'degrees',
                         'longitude': 'degrees'}
 

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -4,6 +4,7 @@
 """Read upper air data from the Integrated Global Radiosonde Archive version 2."""
 
 import datetime
+from contextlib import closing
 from io import BytesIO
 from io import StringIO
 import itertools
@@ -19,13 +20,13 @@ try:
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
-    
+
 warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created', UserWarning)
 
 
 class IGRAUpperAir:
     """Download and parse data from NCEI's Integrated Radiosonde Archive version 2."""
-    
+
     def __init__(self):
         """Set ftp site address and file suffix based on desired dataset."""
         self.ftpsite = 'ftp://ftp.ncdc.noaa.gov/pub/data/igra/'
@@ -50,8 +51,8 @@ class IGRAUpperAir:
         Returns
         -------
             :class: `pandas.DataFrame` containing the data.
-        """
 
+        """
         igra2 = cls()
 
         # Set parameters for data query
@@ -105,7 +106,7 @@ class IGRAUpperAir:
         Returns a tuple with a string for the body, string for the headers,
         and a list of dates.
         """
-        with urlopen(self.ftpsite + self.site_id + self.suffix + '.zip') as url:
+        with closing(urlopen(self.ftpsite + self.site_id + self.suffix + '.zip')) as url:
             f = ZipFile(BytesIO(url.read()), 'r').open(self.site_id + self.suffix)
 
         lines = [line.decode('utf-8') for line in f.readlines()]
@@ -121,8 +122,8 @@ class IGRAUpperAir:
         -----
         lines: list
             list of lines from the IGRA2 data file.
-        """
 
+        """
         headers = []
         num_lev = []
         dates = []
@@ -174,16 +175,14 @@ class IGRAUpperAir:
 
         Returns a dict with entries 'body' and 'header'.
         """
-
         def _cdec(power=1):
             """Make a function to convert string 'value*10^power' to float."""
             def _cdec_power(val):
-                return float(val)/10**power
+                return float(val) / 10**power
             return _cdec_power
 
         def _cflag(val):
             """Replace alphabetic flags A and B with numeric."""
-
             if val == 'A':
                 return 1
             elif val == 'B':

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2015 University Corporation for Atmospheric Research/Unidata.
+# Copyright (c) 2018 University Corporation for Atmospheric Research/Unidata.
 # Distributed under the terms of the MIT License.
 # SPDX-License-Identifier: MIT
 """Read upper air data from the Integrated Global Radiosonde Archive version 2."""
@@ -8,7 +8,6 @@ from io import BytesIO
 from io import StringIO
 import itertools
 import sys
-from urllib.request import urlopen
 import warnings
 from zipfile import ZipFile
 
@@ -16,13 +15,14 @@ import numpy as np
 import pandas as pd
 
 from .._tools import get_wind_components
+from urllib.request import urlopen
 
 warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created', UserWarning)
 
 
 class IGRAUpperAir:
-    """Download and parse data from NCEI's Integrated Radiosonde Archive version 2.
-    """
+    """Download and parse data from NCEI's Integrated Radiosonde Archive version 2."""
+    
     def __init__(self):
         """Set ftp site address and file suffix based on desired dataset."""
         self.ftpsite = 'ftp://ftp.ncdc.noaa.gov/pub/data/igra/'
@@ -31,7 +31,6 @@ class IGRAUpperAir:
         self.end_date = ''
         self.site_id = ''
 
-        
     @classmethod
     def request_data(cls, time, site_id, derived=False):
         """Retreive IGRA version 2 data for one station.
@@ -49,6 +48,7 @@ class IGRAUpperAir:
         -------
             :class: `pandas.DataFrame` containing the data.
         """
+
         igra2 = cls()
 
         # Set parameters for data query
@@ -119,6 +119,7 @@ class IGRAUpperAir:
         lines: list
             list of lines from the IGRA2 data file.
         """
+
         headers = []
         num_lev = []
         dates = []
@@ -153,7 +154,7 @@ class IGRAUpperAir:
 
         # Make a boolean vector that selects only list indices within the time range
         selector = np.zeros(len(lines), dtype=bool)
-        selector[begin_idx:end_idx+1] = True
+        selector[begin_idx:end_idx + 1] = True
         selector[headers] = False
         body = ''.join([line for line in itertools.compress(lines, selector)])
 
@@ -167,7 +168,7 @@ class IGRAUpperAir:
 
     def _get_fwf_params(self):
         """Produce a dictionary with names, colspecs, and dtype for IGRA2 data.
-        
+
         Returns a dict with entries 'body' and 'header'.
         """
 
@@ -179,6 +180,7 @@ class IGRAUpperAir:
 
         def _cflag(val):
             """Replace alphabetic flags A and B with numeric."""
+
             if val == 'A':
                 return 1
             elif val == 'B':
@@ -187,8 +189,7 @@ class IGRAUpperAir:
                 return 0
 
         def _ctime(strformat='MMMSS'):
-            """Returns a function converting a string from MMMSS or HHMM to seconds.
-            """
+            """Return a function converting a string from MMMSS or HHMM to seconds."""
             def _ctime_strformat(val):
                 time = val.strip().zfill(5)
 

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -21,8 +21,7 @@ warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created',
 
 
 class IGRAUpperAir:
-    """Download and parse data from NCEI's Integrated Radiosonde
-    Archive version 2.
+    """Download and parse data from NCEI's Integrated Radiosonde Archive version 2.
     """
     def __init__(self):
         """Set ftp site address and file suffix based on desired dataset."""
@@ -32,6 +31,7 @@ class IGRAUpperAir:
         self.end_date = ''
         self.site_id = ''
 
+        
     @classmethod
     def request_data(cls, time, site_id, derived=False):
         """Retreive IGRA version 2 data for one station.
@@ -72,8 +72,7 @@ class IGRAUpperAir:
         return df, headers
 
     def _get_data(self):
-        """Process the IGRA2 text file for observations at site_id
-        matching time.
+        """Process the IGRA2 text file for observations at site_id matching time.
 
         Return:
         -------
@@ -98,8 +97,7 @@ class IGRAUpperAir:
         return df_body, df_header
 
     def _get_data_raw(self):
-        """Download the IGRA2 file containing site_id observations,
-        and search for observations matching the time range.
+        """Download observations matching the time range.
 
         Returns a tuple with a string for the body, string for the headers,
         and a list of dates.
@@ -114,8 +112,7 @@ class IGRAUpperAir:
         return body, header, dates_long, dates
 
     def _select_date_range(self, lines):
-        """Run through the data and identify lines containing
-        headers within the range begin_date to end_date.
+        """Identify lines containing headers within the range begin_date to end_date.
 
         Parameters
         -----
@@ -160,7 +157,7 @@ class IGRAUpperAir:
         selector[headers] = False
         body = ''.join([line for line in itertools.compress(lines, selector)])
 
-        selector[begin_idx:end_idx+1] = ~selector[begin_idx:end_idx+1]
+        selector[begin_idx:end_idx + 1] = ~selector[begin_idx:end_idx + 1]
         header = ''.join([line for line in itertools.compress(lines, selector)])
 
         # expand date vector to match length of the body dataframe.
@@ -170,18 +167,18 @@ class IGRAUpperAir:
 
     def _get_fwf_params(self):
         """Produce a dictionary with names, colspecs, and dtype for IGRA2 data.
+        
         Returns a dict with entries 'body' and 'header'.
         """
 
         def _cdec(power=1):
-            """Make a function that takes input string in form value*10^power,
-            and return as float."""
+            """Make a function to convert string 'value*10^power' to float."""
             def _cdec_power(val):
                 return float(val)/10**power
             return _cdec_power
 
         def _cflag(val):
-            """Replace alphabetic flags A and B with numeric"""
+            """Replace alphabetic flags A and B with numeric."""
             if val == 'A':
                 return 1
             elif val == 'B':
@@ -190,8 +187,7 @@ class IGRAUpperAir:
                 return 0
 
         def _ctime(strformat='MMMSS'):
-            """Convert a time string from MMMSS or HHMM to seconds,
-            returning a function that takes a string input "val".
+            """Returns a function converting a string from MMMSS or HHMM to seconds.
             """
             def _ctime_strformat(val):
                 time = val.strip().zfill(5)
@@ -204,11 +200,11 @@ class IGRAUpperAir:
                     if strformat == 'MMMSS':
                         minutes = int(time[0:3])
                         seconds = int(time[3:5])
-                        time_seconds = minutes*60 + seconds
+                        time_seconds = minutes * 60 + seconds
                     elif strformat == 'HHMM':
                         hours = int(time[0:2])
                         minutes = int(time[2:4])
-                        time_seconds = hours*3600 + minutes*60
+                        time_seconds = hours * 3600 + minutes * 60
                     else:
                         sys.exit('Unrecognized time format')
 
@@ -217,8 +213,8 @@ class IGRAUpperAir:
 
         def _clatlon(x):
             n = len(x)
-            deg = x[0:n-4]
-            dec = x[n-4:]
+            deg = x[0:n - 4]
+            dec = x[n - 4:]
             return float(deg + '.' + dec)
 
         if self.suffix == '-drvd.txt':
@@ -334,7 +330,7 @@ class IGRAUpperAir:
 
             na_vals = ['-8888', '-9999']
 
-            conv_header = {'release_time': _ctime(strformat="HHMM"),
+            conv_header = {'release_time': _ctime(strformat='HHMM'),
                            'number_levels': int,
                            'latitude': _clatlon,
                            'longitude': _clatlon}
@@ -352,7 +348,6 @@ class IGRAUpperAir:
 
     def _clean_body_df(self, df):
         """Format the dataframe, remove empty rows, and add units attribute."""
-
         if self.suffix == '-drvd.txt':
             df = df.dropna(subset=('temperature', 'reported_relative_humidity',
                                    'u_wind', 'v_wind'), how='all').reset_index(drop=True)
@@ -400,7 +395,7 @@ class IGRAUpperAir:
         return df
 
     def _clean_header_df(self, df):
-        """Format the header dataframe and add units"""
+        """Format the header dataframe and add units."""
         if self.suffix == '-drvd.txt':
             df.units = {'release_time': 'second',
                         'precipitable_water': 'millimeter',

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -50,7 +50,7 @@ class IGRAUpperAir:
             :class: `pandas.DataFrame` containing the data.
         """
         igra2 = cls()
-        
+
         # Set parameters for data query
         if derived:
             igra2.ftpsite = igra2.ftpsite + 'derived/derived-por/'

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -1,0 +1,436 @@
+# Copyright (c) 2013-2015 University Corporation for Atmospheric Research/Unidata.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""Read upper air data from the Integrated Global Radiosonde Archive version 2."""
+
+import datetime
+import warnings
+import itertools
+import numpy as np
+import pandas as pd
+import sys
+
+from io import BytesIO
+from io import StringIO
+from zipfile import ZipFile
+from urllib.request import urlopen
+from .._tools import get_wind_components
+
+warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created', UserWarning)
+
+
+class IGRAUpperAir:
+    """Download and parse data from NCEI's Integrated Radiosonde
+    Archive version 2.
+    """
+
+    def __init__(self):
+        """Set ftp site address and file suffix based on desired dataset"""
+
+        self.ftpsite = 'ftp://ftp.ncdc.noaa.gov/pub/data/igra/'
+        self.suffix = ''
+        self.begin_date = ''
+        self.end_date = ''
+        self.site_id = ''
+
+    @classmethod
+    def request_data(cls, time, site_id, derived=False):
+        """Retreive IGRA version 2 data for one station.
+
+        Parameters
+        --------
+        site_id : str
+            11-character IGRA2 station identifier
+
+        time : datetime
+           The date and time of the desired observation. If list of two times is given,
+           dataframes for all dates within the two dates will be returned.
+
+        Returns
+        -------
+            :class: `pandas.DataFrame` containing the data
+        """
+
+        igra2 = cls()
+        
+        # Set parameters for data query
+        if derived:
+            igra2.ftpsite = igra2.ftpsite + 'derived/derived-por/'
+            igra2.suffix = igra2.suffix + '-drvd.txt'
+        else:
+            igra2.ftpsite = igra2.ftpsite + 'data/data-por/'
+            igra2.suffix = igra2.suffix + '-data.txt'
+
+        if type(time) == datetime.datetime:
+            igra2.begin_date = time
+            igra2.end_date = time
+        else:
+            igra2.begin_date, igra2.end_date = time
+
+        igra2.site_id = site_id
+
+        df, headers = igra2._get_data()
+
+        return df, headers
+
+    def _get_data(self):
+        """Process the IGRA2 text file for observations at site_id
+        matching time.
+
+        Return:
+        -------
+            :class: `pandas.DataFrame` containing the body data
+            :class: `pandas.DataFrame` containing the header data
+        """
+
+        # Split the list of times into begin and end dates. If only
+        # one date is supplied, set both begin and end dates equal to that date.
+
+        body, header, dates_long, dates = self._get_data_raw()
+
+        params = self._get_fwf_params()
+
+        df_body = pd.read_fwf(StringIO(body), **params['body'])
+        df_header = pd.read_fwf(StringIO(header), **params['header'])
+        df_body['date'] = dates_long
+
+        df_body = self._clean_body_df(df_body)
+        df_header = self._clean_header_df(df_header)
+        df_header['date'] = dates
+
+        return df_body, df_header
+
+    def _get_data_raw(self):
+        """Download the IGRA2 file containing site_id observations,
+        and search for observations matching the time range. Returns a tuple
+        with a string for the body, string for the headers, and a list of dates
+        """
+
+        with urlopen(self.ftpsite + self.site_id + self.suffix + '.zip') as url:
+            f = ZipFile(BytesIO(url.read()), 'r').open(self.site_id + self.suffix)
+
+        lines = [line.decode('utf-8') for line in f.readlines()]
+
+        body, header, dates_long, dates = self._select_date_range(lines)
+
+        return body, header, dates_long, dates
+
+    def _select_date_range(self, lines):
+        """Run through the data and identify lines containing
+        headers within the range begin_date to end_date.
+
+        Parameters
+        -----
+        lines: list
+            list of lines from the IGRA2 data file
+        """
+        headers = []
+        num_lev = []
+        dates = []
+
+        # Get indices of headers, and make a list of dates and num_lev
+        for idx, line in enumerate(lines):
+            if line[0] == '#':
+                year, month, day, hour = map(int, line[13:26].split())
+
+                # All soundings have YMD, most have hour
+                try:
+                    date = datetime.datetime(year, month, day, hour)
+                except ValueError:
+                    date = datetime.datetime(year, month, day)
+
+                # Check date
+                if self.begin_date <= date <= self.end_date:
+                    headers.append(idx)
+                    num_lev.append(int(line[32:36]))
+                    dates.append(date)
+                if date > self.end_date:
+                    break
+
+        if len(dates) == 0:
+            # Break if no matched dates.
+            # Could improve this later by showing the date range for the station.
+            raise ValueError('No dates match selection.')
+
+        # Compress body of data into a string
+        begin_idx = min(headers)
+        end_idx = max(headers) + num_lev[-1]
+
+        # Make a boolean vector that selects only list indices within the time range
+        selector = np.zeros(len(lines), dtype=bool)
+        selector[begin_idx:end_idx+1] = True
+        selector[headers] = False
+        body = ''.join([line for line in itertools.compress(lines, selector)])
+
+        selector[begin_idx:end_idx+1] = ~selector[begin_idx:end_idx+1]
+        header = ''.join([line for line in itertools.compress(lines, selector)])
+
+        # expand date vector to match length of the body dataframe.
+        dates_long = np.repeat(dates, num_lev)
+
+        return body, header, dates_long, dates
+
+    def _get_fwf_params(self):
+        """Produce a dictionary with names, colspecs, and dtype for IGRA2 data.
+        Returns a dict with entries 'body' and 'header'. """
+
+        def _cdec(power=1):
+            """Make a function that takes input string in form value*10^power,
+            and return as float."""
+            def _cdec_power(val):
+                return float(val)/10**power
+            return _cdec_power
+
+        def _cflag(val):
+            """Replace alphabetic flags A and B with numeric"""
+            if val == 'A':
+                return 1
+            elif val == 'B':
+                return 2
+            else:
+                return 0
+
+        def _ctime(strformat='MMMSS'):
+            """Returns a function converting time string from
+            MMMSS or HHMM to seconds. Returned function takes
+            a string input "val"
+            """
+
+            def _ctime_strformat(val):
+                time = val.strip().zfill(5)
+
+                if int(time) < 0:
+                    return np.nan
+                elif int(time) == 9999:
+                    return np.nan
+                else:
+                    if strformat == 'MMMSS':
+                        minutes = int(time[0:3])
+                        seconds = int(time[3:5])
+                        time_seconds = minutes*60 + seconds
+                    elif strformat == 'HHMM':
+                        hours = int(time[0:2])
+                        minutes = int(time[2:4])
+                        time_seconds = hours*3600 + minutes*60
+                    else:
+                        sys.exit('Unrecognized time format')
+
+                return time_seconds
+            return _ctime_strformat
+
+        def _clatlon(x):
+            n = len(x)
+            deg = x[0:n-4]
+            dec = x[n-4:]
+            return float(deg + '.' + dec)
+
+        if self.suffix == '-drvd.txt':
+            names_body = ['pressure', 'reported_height', 'calculated_height',
+                          'temperature', 'temperature_gradient', 'potential_temperature',
+                          'potential_temperature_gradient', 'virtual_temperature',
+                          'virtual_potential_temperature', 'vapor_pressure',
+                          'saturation_vapor_pressure', 'reported_relative_humidity',
+                          'calculated_relative_humidity', 'u_wind', 'u_wind_gradient',
+                          'v_wind', 'v_wind_gradient', 'refractive_index']
+
+            colspecs_body = [(0, 7), (8, 15), (16, 23), (24, 31), (32, 39),
+                             (40, 47), (48, 55), (56, 63), (64, 71), (72, 79),
+                             (80, 87), (88, 95), (96, 103), (104, 111), (112, 119),
+                             (120, 127), (128, 135), (137, 143), (144, 151)]
+
+            conv_body = {'pressure': _cdec(power=2),
+                         'reported_height': int,
+                         'calculated_height': int,
+                         'temperature': _cdec(),
+                         'temperature_gradient': _cdec(),
+                         'potential_temperature': _cdec(),
+                         'potential_temperature_gradient': _cdec(),
+                         'virtual_temperature': _cdec(),
+                         'virtual_potential_temperature': _cdec(),
+                         'vapor_pressure': _cdec(power=3),
+                         'saturation_vapor_pressure': _cdec(power=3),
+                         'reported_relative_humidity': int,
+                         'calculated_relative_humidity': int,
+                         'u_wind': _cdec(),
+                         'u_wind_gradient': _cdec(),
+                         'v_wind': _cdec(),
+                         'v_wind_gradient': _cdec(),
+                         'refractive_index': int}
+
+            names_header = ['site_id', 'year', 'month', 'day', 'hour', 'release_time',
+                            'number_levels', 'precipitable_water', 'inv_pressure',
+                            'inv_height', 'inv_strength', 'mixed_layer_pressure',
+                            'mixed_layer_height', 'freezing_point_pressure',
+                            'freezing_point_height', 'lcl_pressure', 'lcl_height',
+                            'lfc_pressure', 'lfc_height', 'lnb_pressure', 'lnb_height',
+                            'lifted_index', 'showalter_index', 'k_index', 'total_totals_index',
+                            'cape', 'convective_inhibition']
+
+            colspecs_header = [(1, 12), (13, 17), (18, 20), (21, 23), (24, 26),
+                               (27, 31), (31, 36), (37, 43), (43, 48), (49, 55),
+                               (55, 61), (61, 67), (67, 73), (73, 79), (79, 85),
+                               (85, 91), (91, 97), (97, 103), (103, 109), (109, 115),
+                               (115, 121), (121, 127), (127, 133), (133, 139),
+                               (139, 145), (145, 151), (151, 157)]
+
+            conv_header = {'site_id': str,
+                           'year': int,
+                           'month': int,
+                           'day': int,
+                           'hour': int,
+                           'release_time': _ctime(strformat="HHMM"),
+                           'number_levels': int,
+                           'precipitable_water': _cdec(power=2),
+                           'inv_pressure': _cdec(power=2),
+                           'inv_height': int,
+                           'inv_strength': _cdec(),
+                           'mixed_layer_pressure': _cdec(power=2),
+                           'mixed_layer_height': int,
+                           'freezing_point_pressure': _cdec(power=2),
+                           'freezing_point_height': int,
+                           'lcl_pressure': _cdec(power=2),
+                           'lcl_height': int,
+                           'lfc_pressure': _cdec(power=2),
+                           'lfc_height': int,
+                           'lnb_pressure': _cdec(power=2),
+                           'lnb_height': int,
+                           'lifted_index': int,
+                           'showalter_index': int,
+                           'k_index': int,
+                           'total_totals_index': int,
+                           'cape': int,
+                           'convective_inhibition': int}
+
+            na_vals = ['-99999']
+
+        else:
+            names_body = ['lvltyp1', 'lvltyp2', 'etime', 'pressure',
+                          'pflag', 'height', 'zflag', 'temperature', 'tflag',
+                          'relative_humidity', 'dewpoint_depression',
+                          'direction', 'speed']
+
+            colspecs_body = [(0, 1), (1, 2), (3, 8), (9, 15), (15, 16),
+                             (16, 21), (21, 22), (22, 27), (27, 28),
+                             (28, 33), (34, 39), (40, 45), (46, 51)]
+
+            conv_body = {'lvltyp1': int,
+                         'lvltyp2': int,
+                         'etime': _ctime(strformat="MMMSS"),
+                         'pressure': _cdec(power=2),
+                         'pflag': _cflag,
+                         'height': int,
+                         'zflag': _cflag,
+                         'temperature': _cdec(),
+                         'tflag': _cflag,
+                         'relative_humidity': _cdec(),
+                         'dewpoint_depression': _cdec(),
+                         'direction': int,
+                         'speed': _cdec()}
+
+            names_header = ['site_id', 'year', 'month', 'day', 'hour', 'release_time',
+                            'number_levels', 'pressure_source_code',
+                            'non_pressure_source_code',
+                            'latitude', 'longitude']
+
+            colspecs_header = [(1, 12), (13, 17), (18, 20), (21, 23), (24, 26),
+                               (27, 31), (32, 36), (37, 45), (46, 54), (55, 62), (63, 71)]
+
+            na_vals = ['-8888', '-9999']
+
+            conv_header = {'release_time': _ctime(strformat="HHMM"),
+                           'number_levels': int,
+                           'latitude': _clatlon,
+                           'longitude': _clatlon}
+
+        return {'body': {'names': names_body,
+                         'colspecs': colspecs_body,
+                         'converters': conv_body,
+                         'na_values': na_vals,
+                         'index_col': False},
+                'header': {'names': names_header,
+                           'colspecs': colspecs_header,
+                           'converters': conv_header,
+                           'na_values': na_vals,
+                           'index_col': False}}
+
+    def _clean_body_df(self, df):
+        """Format the dataframe, remove empty rows, and add units attribute."""
+
+        if self.suffix == '-drvd.txt':
+
+            df.units = {'pressure': 'hPa',
+                        'reported_height': 'm',
+                        'calculated_height': 'm',
+                        'temperature': 'K',
+                        'temperature_gradient': 'K/km',
+                        'potential_temperature': 'K',
+                        'potential_temperature_gradient': 'K/km',
+                        'virtual_temperature': 'K',
+                        'virtual_potential_temperature': 'K',
+                        'vapor_pressure': 'Pa',
+                        'saturation_vapor_pressure': 'Pa',
+                        'reported_relative_humidity': '%',
+                        'calculated_relative_humidity': '%',
+                        'u_wind': 'm/s',
+                        'u_wind_gradient': '(m/s) / km)',
+                        'v_wind': 'meter/second',
+                        'v_wind_gradient': '(m/s) / km)',
+                        'refractive_index': 'unitless'}
+
+            df = df.dropna(subset=('temperature', 'reported_relative_humidity',
+                                   'u_wind', 'v_wind'), how='all').reset_index(drop=True)
+
+        else:
+            df['u_wind'], df['v_wind'] = get_wind_components(df['speed'],
+                                                             np.deg2rad(df['direction']))
+            df['u_wind'] = np.round(df['u_wind'], 1)
+            df['v_wind'] = np.round(df['v_wind'], 1)
+            df['dewpoint'] = df['temperature'] - df['dewpoint_depression']
+
+            df.drop('dewpoint_depression', axis=1, inplace=True)
+            df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
+                                   'u_wind', 'v_wind'), how='all').reset_index(drop=True)
+
+            df.units = {'etime': 's',
+                        'pressure': 'hPa',
+                        'height': 'm',
+                        'temperature': 'degC',
+                        'dewpoint': 'degC',
+                        'direction': 'degrees',
+                        'speed': 'm/s',
+                        'u_wind': 'm/s',
+                        'v_wind': 'm/s'}
+
+        return df
+
+    def _clean_header_df(self, df):
+        """Format the header dataframe and add units"""
+        if self.suffix == '-drvd.txt':
+            df.units = {'release_time': 's',
+                        'precipitable_water': 'mm',
+                        'inv_pressure': 'hPa',
+                        'inv_height': 'm',
+                        'inv_strength': 'K',
+                        'mixed_layer_pressure': 'hPa',
+                        'mixed_layer_height': 'm',
+                        'freezing_point_pressure': 'hPa',
+                        'freezing_point_height': 'm',
+                        'lcl_pressure': 'hPa',
+                        'lcl_height': 'm',
+                        'lfc_pressure': 'hPa',
+                        'lfc_height': 'm',
+                        'lnb_pressure': 'hPa',
+                        'lnb_height': 'm',
+                        'lifted_index': 'degC',
+                        'showalter_index': 'degC',
+                        'k_index': 'degC',
+                        'total_totals_index': 'degC',
+                        'cape': 'J/kg',
+                        'convective_inhibition': 'J/kg'}
+
+        else:
+            df.units = {'release_time': 's',
+                        'latitude': 'degrees',
+                        'latitude': 'degrees'}
+
+        return df

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -15,8 +15,11 @@ import numpy as np
 import pandas as pd
 
 from .._tools import get_wind_components
-from urllib.request import urlopen
-
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+    
 warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created', UserWarning)
 
 

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MIT
 """Read upper air data from the Integrated Global Radiosonde Archive version 2."""
 
-import datetime
 from contextlib import closing
+import datetime
 from io import BytesIO
 from io import StringIO
 import itertools

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -4,16 +4,17 @@
 """Read upper air data from the Integrated Global Radiosonde Archive version 2."""
 
 import datetime
-import warnings
 import itertools
-import numpy as np
-import pandas as pd
-import sys
-
 from io import BytesIO
 from io import StringIO
-from zipfile import ZipFile
 from urllib.request import urlopen
+from zipfile import ZipFile
+import sys
+import warnings
+import numpy as np
+import pandas as pd
+
+
 from .._tools import get_wind_components
 
 warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created', UserWarning)
@@ -23,10 +24,8 @@ class IGRAUpperAir:
     """Download and parse data from NCEI's Integrated Radiosonde
     Archive version 2.
     """
-
     def __init__(self):
-        """Set ftp site address and file suffix based on desired dataset"""
-
+        """Set ftp site address and file suffix based on desired dataset."""
         self.ftpsite = 'ftp://ftp.ncdc.noaa.gov/pub/data/igra/'
         self.suffix = ''
         self.begin_date = ''
@@ -40,7 +39,7 @@ class IGRAUpperAir:
         Parameters
         --------
         site_id : str
-            11-character IGRA2 station identifier
+            11-character IGRA2 station identifier.
 
         time : datetime
            The date and time of the desired observation. If list of two times is given,
@@ -48,9 +47,8 @@ class IGRAUpperAir:
 
         Returns
         -------
-            :class: `pandas.DataFrame` containing the data
+            :class: `pandas.DataFrame` containing the data.
         """
-
         igra2 = cls()
         
         # Set parameters for data query
@@ -79,10 +77,9 @@ class IGRAUpperAir:
 
         Return:
         -------
-            :class: `pandas.DataFrame` containing the body data
-            :class: `pandas.DataFrame` containing the header data
+            :class: `pandas.DataFrame` containing the body data.
+            :class: `pandas.DataFrame` containing the header data.
         """
-
         # Split the list of times into begin and end dates. If only
         # one date is supplied, set both begin and end dates equal to that date.
 
@@ -102,10 +99,11 @@ class IGRAUpperAir:
 
     def _get_data_raw(self):
         """Download the IGRA2 file containing site_id observations,
-        and search for observations matching the time range. Returns a tuple
-        with a string for the body, string for the headers, and a list of dates
-        """
+        and search for observations matching the time range.
 
+        Returns a tuple with a string for the body, string for the headers,
+        and a list of dates.
+        """
         with urlopen(self.ftpsite + self.site_id + self.suffix + '.zip') as url:
             f = ZipFile(BytesIO(url.read()), 'r').open(self.site_id + self.suffix)
 
@@ -122,7 +120,7 @@ class IGRAUpperAir:
         Parameters
         -----
         lines: list
-            list of lines from the IGRA2 data file
+            list of lines from the IGRA2 data file.
         """
         headers = []
         num_lev = []
@@ -172,7 +170,8 @@ class IGRAUpperAir:
 
     def _get_fwf_params(self):
         """Produce a dictionary with names, colspecs, and dtype for IGRA2 data.
-        Returns a dict with entries 'body' and 'header'. """
+        Returns a dict with entries 'body' and 'header'.
+        """
 
         def _cdec(power=1):
             """Make a function that takes input string in form value*10^power,
@@ -191,11 +190,9 @@ class IGRAUpperAir:
                 return 0
 
         def _ctime(strformat='MMMSS'):
-            """Returns a function converting time string from
-            MMMSS or HHMM to seconds. Returned function takes
-            a string input "val"
+            """Convert a time string from MMMSS or HHMM to seconds,
+            returning a function that takes a string input "val".
             """
-
             def _ctime_strformat(val):
                 time = val.strip().zfill(5)
 
@@ -278,7 +275,7 @@ class IGRAUpperAir:
                            'month': int,
                            'day': int,
                            'hour': int,
-                           'release_time': _ctime(strformat="HHMM"),
+                           'release_time': _ctime(strformat='HHMM'),
                            'number_levels': int,
                            'precipitable_water': _cdec(power=2),
                            'inv_pressure': _cdec(power=2),
@@ -315,7 +312,7 @@ class IGRAUpperAir:
 
             conv_body = {'lvltyp1': int,
                          'lvltyp2': int,
-                         'etime': _ctime(strformat="MMMSS"),
+                         'etime': _ctime(strformat='MMMSS'),
                          'pressure': _cdec(power=2),
                          'pflag': _cflag,
                          'height': int,
@@ -431,6 +428,6 @@ class IGRAUpperAir:
         else:
             df.units = {'release_time': 's',
                         'latitude': 'degrees',
-                        'latitude': 'degrees'}
+                        'longitude': 'degrees'}
 
         return df

--- a/siphon/tests/test_igra2.py
+++ b/siphon/tests/test_igra2.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2018 University Corporation for Atmospheric Research/Unidata.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""Test IGRA2 upper air dataset access."""
+
+from datetime import datetime
+
+from numpy.testing import assert_almost_equal
+
+from siphon.simplewebservice.igra2 import IGRA2UpperAir
+from siphon.testing import get_recorder
+
+
+recorder = get_recorder(__file__)
+
+@recorder.use_cassette('igra2_sounding')
+def test_igra2():
+    """Test that we are properly parsing data from the IGRA2 archive."""
+    df, header = IGRAUpperAir.request_data(datetime(2010, 6, 1, 12), 'USM00070026')
+
+    assert_almost_equal(df['lvltyp1'][5],1, 1)
+    assert_almost_equal(df['lvltyp2'][5], 0, 1)
+    assert_almost_equal(df['etime'][5], 126, 2)
+    assert_almost_equal(df['pressure'][5], 925.0, 2)
+    assert_almost_equal(df['pflag'][5], 0, 1)
+    assert_almost_equal(df['height'][5], 696., 2)
+    assert_almost_equal(df['zflag'][5], 2, 1)
+    assert_almost_equal(df['temperature'][5], -3.2, 2)
+    assert_almost_equal(df['tflag'][5], 2, 1)
+    assert_almost_equal(df['relative_humidity'][5], 96.3, 2)
+    assert_almost_equal(df['direction'][5], 33.0, 2)
+    assert_almost_equal(df['speed'][5], 8.2, 2)
+    assert_almost_equal(df['u_wind'][5], -4.5, 2)
+    assert_almost_equal(df['v_wind'][5],-6.9, 2)
+    assert_almost_equal(df['dewpoint'][5], -3.7, 2)
+
+    assert(df.units['pressure'] == 'hPa')
+    assert(df.units['height'] == 'meter')
+    assert(df.units['temperature'] == 'degC')
+    assert(df.units['dewpoint'] == 'degC')
+    assert(df.units['u_wind'] == 'meter / second')
+    assert(df.units['v_wind'] == 'meter / second')
+    assert(df.units['speed'] == 'meter / second')
+    assert(df.units['direction'] == 'degrees')
+    assert(df.units['etime'] == 'second')
+
+@recorder.use_cassette('igra2_derived')
+def test_igra2_drvd():
+    """Test that we are properly parsing data from the IGRA2 archive."""
+    df, header = IGRAUpperAir.request_data(datetime(2014, 9, 10, 0), 'USM00070026', derived=True)
+
+    assert_almost_equal(df['pressure'][5], 947.43, 2)
+    assert_almost_equal(df['reported_height'][5], 610., 2)
+    assert_almost_equal(df['calculated_height'][5], 610., 2)
+    assert_almost_equal(df['temperature'][5], 269.1, 2)
+    assert_almost_equal(df['temperature_gradient'][5], 0.0, 2)
+    assert_almost_equal(df['potential_temperature'][5], 273.2, 2)
+    assert_almost_equal(df['potential_temperature_gradient'][5], 11.0, 2)
+    assert_almost_equal(df['virtual_temperature'][5], 269.5, 2)
+    assert_almost_equal(df['virtual_potential_temperature'][5], 273.7, 2)
+    assert_almost_equal(df['vapor_pressure'][5], 4.268, 2)
+    assert_almost_equal(df['saturation_vapor_pressure'][5], 4.533, 2)
+    assert_almost_equal(df['reported_relative_humidity'][5], 939., 2)
+    assert_almost_equal(df['calculated_relative_humidity'][5], 941., 2)
+    assert_almost_equal(df['u_wind'][5], -75.3, 2)
+    assert_almost_equal(df['u_wind_gradient'][5], -7.8, 2)
+    assert_almost_equal(df['v_wind'][5], 9.6, 2)
+    assert_almost_equal(df['v_wind_gradient'][5], -1.2, 2)
+    assert_almost_equal(df['refractive_index'][5], 27.0, 2)
+
+    assert(df.units['pressure'] == 'hPa')
+    assert(df.units['reported_height'] == 'meter')
+    assert(df.units['calculated_height'] == 'meter')
+    assert(df.units['temperature'] == 'Kelvin')
+    assert(df.units['temperature_gradient'] == 'Kelvin / kilometer')
+    assert(df.units['potential_temperature'] == 'Kelvin')
+    assert(df.units['potential_temperature_gradient'] == 'Kelvin / kilometer')
+    assert(df.units['virtual_temperature'] == 'Kelvin')
+    assert(df.units['virtual_potential_temperature'] == 'Kelvin')
+    assert(df.units['vapor_pressure'] == 'Pascal')
+    assert(df.units['saturation_vapor_pressure'] == 'Pascal')
+    assert(df.units['reported_relative_humidity'] == 'percent')
+    assert(df.units['calculated_relative_humidity'] == 'percent')
+    assert(df.units['u_wind'] == 'meter/ssecond')
+    assert(df.units['u_wind_gradient'] == '(meter / second) / kilometer)')
+    assert(df.units['v_wind'] == 'meter / second')
+    assert(df.units['v_wind_gradient'] == '(meter / second) / kilometer)')
+    assert(df.units['refractive_index'] == 'unitless')

--- a/siphon/tests/test_igra2.py
+++ b/siphon/tests/test_igra2.py
@@ -84,7 +84,7 @@ def test_igra2_drvd():
     assert(df.units['saturation_vapor_pressure'] == 'Pascal')
     assert(df.units['reported_relative_humidity'] == 'percent')
     assert(df.units['calculated_relative_humidity'] == 'percent')
-    assert(df.units['u_wind'] == 'meter/ssecond')
+    assert(df.units['u_wind'] == 'meter / second')
     assert(df.units['u_wind_gradient'] == '(meter / second) / kilometer)')
     assert(df.units['v_wind'] == 'meter / second')
     assert(df.units['v_wind_gradient'] == '(meter / second) / kilometer)')

--- a/siphon/tests/test_igra2.py
+++ b/siphon/tests/test_igra2.py
@@ -7,18 +7,19 @@ from datetime import datetime
 
 from numpy.testing import assert_almost_equal
 
-from siphon.simplewebservice.igra2 import IGRA2UpperAir
+from siphon.simplewebservice.igra2 import IGRAUpperAir
 from siphon.testing import get_recorder
 
 
 recorder = get_recorder(__file__)
+
 
 @recorder.use_cassette('igra2_sounding')
 def test_igra2():
     """Test that we are properly parsing data from the IGRA2 archive."""
     df, header = IGRAUpperAir.request_data(datetime(2010, 6, 1, 12), 'USM00070026')
 
-    assert_almost_equal(df['lvltyp1'][5],1, 1)
+    assert_almost_equal(df['lvltyp1'][5], 1, 1)
     assert_almost_equal(df['lvltyp2'][5], 0, 1)
     assert_almost_equal(df['etime'][5], 126, 2)
     assert_almost_equal(df['pressure'][5], 925.0, 2)
@@ -31,7 +32,7 @@ def test_igra2():
     assert_almost_equal(df['direction'][5], 33.0, 2)
     assert_almost_equal(df['speed'][5], 8.2, 2)
     assert_almost_equal(df['u_wind'][5], -4.5, 2)
-    assert_almost_equal(df['v_wind'][5],-6.9, 2)
+    assert_almost_equal(df['v_wind'][5], -6.9, 2)
     assert_almost_equal(df['dewpoint'][5], -3.7, 2)
 
     assert(df.units['pressure'] == 'hPa')
@@ -44,10 +45,12 @@ def test_igra2():
     assert(df.units['direction'] == 'degrees')
     assert(df.units['etime'] == 'second')
 
+
 @recorder.use_cassette('igra2_derived')
 def test_igra2_drvd():
     """Test that we are properly parsing data from the IGRA2 archive."""
-    df, header = IGRAUpperAir.request_data(datetime(2014, 9, 10, 0), 'USM00070026', derived=True)
+    df, header = IGRAUpperAir.request_data(datetime(2014, 9, 10, 0),
+                                           'USM00070026', derived=True)
 
     assert_almost_equal(df['pressure'][5], 947.43, 2)
     assert_almost_equal(df['reported_height'][5], 610., 2)


### PR DESCRIPTION
I modeled the IGRA2 capability on the Wyoming Upper Air code, so to the user the functionality should appear the same. Inside it's a little more complicated, as the IGRA2 data exists as zipped text files, with each text file including the full station sounding record (in some cases going back to the 1930s). Most of the code is simply encoding the formatting from the IGRA2 read me files - it's not as simple as the Wyoming requests since the sounding headers do not include column names, but rather include metadata and calculated variables. The function allows the user to request a single sounding or all the soundings within a time span. 

The file IGRA2_Request.py shows examples for single soundings from the standard and derived archives, and for pulling data ranges.