### PR TITLE
BUG: Fix error path in HTTPEndPoint

### DIFF
--- a/siphon/http_util.py
+++ b/siphon/http_util.py
@@ -454,7 +454,7 @@ class HTTPEndPoint(object):
         """
         resp = self._session.get(path, params=params)
         if resp.status_code != 200:
-            if resp.headers['Content-Type'].startswith('text/html'):
+            if resp.headers.get('Content-Type', '').startswith('text/html'):
                 text = resp.reason
             else:
                 text = resp.text

--- a/siphon/tests/fixtures/gfs-error-no-header
+++ b/siphon/tests/fixtures/gfs-error-no-header
@@ -1,0 +1,21 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.1+29.g0a00acf.dirty)]
+    method: GET
+    uri: http://thredds.ucar.edu/thredds/ncss/grib/NCEP/GFS/Global_0p5deg/GFS_Global_0p5deg_20180223_1200.grib2?var=u-component_of_wind_isobaric&time=2018-02-23T22%3A28%3A49
+  response:
+    body: {string: 'Requested time 2018-02-23T22:28:49Z does not intersect actual
+        time range 2018-02-26T06:00:00Z - 2018-02-26T06:00:00Z'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [close]
+      Date: ['Fri, 23 Feb 2018 23:06:26 GMT']
+      Server: [Apache]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 400, message: '400'}
+version: 1

--- a/siphon/tests/test_http_util.py
+++ b/siphon/tests/test_http_util.py
@@ -138,6 +138,17 @@ def test_data_query_add():
     assert str(dr) == 'foo=bar'
 
 
+@recorder.use_cassette('gfs-error-no-header')
+def test_http_error_no_header():
+    """Test getting an error back without Content-Type."""
+    endpoint = HTTPEndPoint('http://thredds.ucar.edu/thredds/ncss/grib/NCEP/GFS/'
+                            'Global_0p5deg/GFS_Global_0p5deg_20180223_1200.grib2')
+    query = endpoint.query().variables('u-component_of_wind_isobaric')
+    query.time(datetime(2018, 2, 23, 22, 28, 49))
+    with pytest.raises(HTTPError):
+        endpoint.get_query(query)
+
+
 class TestEndPoint(object):
     """Test the HTTPEndPoint."""
 


### PR DESCRIPTION
We were assuming that Content-Type was always available in the headers, which isn't the case when NCSS fails.

This changes:
```pytb
Traceback (most recent call last):
  File "250hPa_Hemispheric_Plot.py", line 46, in <module>
    data = ncss.get_data(gfsdata)
  File "/Users/rmay/repos/siphon/siphon/ncss.py", line 114, in get_data
    resp = self.get_query(query)
  File "/Users/rmay/repos/siphon/siphon/http_util.py", line 379, in get_query
    return self.get(url, query)
  File "/Users/rmay/repos/siphon/siphon/http_util.py", line 457, in get
    if resp.headers['Content-Type'].startswith('text/html'):
  File "/Users/rmay/miniconda3/envs/py36/lib/python3.6/site-packages/requests/structures.py", line 54, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'content-type'
```
to
```pytb
Traceback (most recent call last):
  File "250hPa_Hemispheric_Plot.py", line 46, in <module>
    data = ncss.get_data(gfsdata)
  File "/Users/rmay/repos/siphon/siphon/ncss.py", line 114, in get_data
    resp = self.get_query(query)
  File "/Users/rmay/repos/siphon/siphon/http_util.py", line 379, in get_query
    return self.get(url, query)
  File "/Users/rmay/repos/siphon/siphon/http_util.py", line 463, in get
    text))
requests.exceptions.HTTPError: Error accessing http://thredds.ucar.edu/thredds/ncss/grib/NCEP/GFS/Global_0p5deg/GFS_Global_0p5deg_20180223_1200.grib2?var=u-component_of_wind_isobaric&var=v-component_of_wind_isobaric&var=Geopotential_height_isobaric&time=2018-02-23T22%3A28%3A49.823819&west=0&east=360&south=0&north=90&accept=netcdf4&addLatLon=True&vertCoord=25000: 400 Requested time 2018-02-23T22:28:49.823Z does not intersect actual time range 2018-02-26T06:00:00Z - 2018-02-26T06:00:00Z
```