### PR TITLE
Port Iowa State Soundings from MetPy

### DIFF
--- a/siphon/simplewebservice/iastate.py
+++ b/siphon/simplewebservice/iastate.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2013-2018 University Corporation for Atmospheric Research/Unidata.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""Read upper air data from the IA State archives."""
+
+import json
+import warnings
+
+import numpy as np
+import numpy.ma as ma
+import pandas as pd
+
+from .._tools import get_wind_components
+from ..http_util import HTTPEndPoint
+
+warnings.filterwarnings('ignore', 'Pandas doesn\'t allow columns to be created', UserWarning)
+
+
+class IAStateUpperAir(HTTPEndPoint):
+    """Download and parse data from the Iowa State's upper air archive."""
+
+    def __init__(self):
+        """Set up endpoint."""
+        super(IAStateUpperAir, self).__init__('http://mesonet.agron.iastate.edu/json')
+
+    @classmethod
+    def request_data(cls, time, site_id, **kwargs):
+        """Retrieve upper air observations from Iowa State's upper air archive.
+
+        Parameters
+        ----------
+        time : datetime
+            The date and time of the desired observation.
+
+        site_id : str
+            The three letter ICAO identifier of the station for which data should be
+            downloaded.
+
+        kwargs
+            Arbitrary keyword arguments to use to initialize source
+
+        Returns
+        -------
+            :class:`pandas.DataFrame` containing the data
+
+        """
+        endpoint = cls()
+        df = endpoint._get_data(time, site_id, **kwargs)
+        return df
+
+    def _get_data(self, time, site_id):
+        """Download data from Iowa State's upper air archive.
+
+        Parameters
+        ----------
+        time : datetime
+            Date and time for which data should be downloaded
+        site_id : str
+            Site id for which data should be downloaded
+
+        Returns
+        -------
+            :class:`pandas.DataFrame` containing the data
+
+        """
+        json_data = self._get_data_raw(time, site_id)
+
+        data = {}
+        for pt in json_data:
+            for field in ('drct', 'dwpc', 'hght', 'pres', 'sknt', 'tmpc'):
+                data.setdefault(field, []).append(np.nan if pt[field] is None else pt[field])
+
+        # Make sure that the first entry has a valid temperature and dewpoint
+        idx = np.argmax(~(np.isnan(data['tmpc']) | np.isnan(data['dwpc'])))
+
+        # Stuff data into a pandas dataframe
+        df = pd.DataFrame()
+        df['pressure'] = ma.masked_invalid(data['pres'][idx:])
+        df['height'] = ma.masked_invalid(data['hght'][idx:])
+        df['temperature'] = ma.masked_invalid(data['tmpc'][idx:])
+        df['dewpoint'] = ma.masked_invalid(data['dwpc'][idx:])
+        df['direction'] = ma.masked_invalid(data['drct'][idx:])
+        df['speed'] = ma.masked_invalid(data['sknt'][idx:])
+
+        # Calculate the u and v winds
+        df['u_wind'], df['v_wind'] = get_wind_components(df['speed'],
+                                                         np.deg2rad(df['direction']))
+
+        # Drop any rows with all NaN values for T, Td, winds
+        df = df.dropna(subset=('temperature', 'dewpoint', 'direction', 'speed',
+                               'u_wind', 'v_wind'), how='all').reset_index(drop=True)
+
+        # Add unit dictionary
+        df.units = {'pressure': 'hPa',
+                    'height': 'meter',
+                    'temperature': 'degC',
+                    'dewpoint': 'degC',
+                    'direction': 'degrees',
+                    'speed': 'knot',
+                    'u_wind': 'knot',
+                    'v_wind': 'knot'}
+
+        return df
+
+    def _get_data_raw(self, time, site_id):
+        r"""Download data from the Iowa State's upper air archive.
+
+        Parameters
+        ----------
+        time : datetime
+            Date and time for which data should be downloaded
+        site_id : str
+            Site id for which data should be downloaded
+
+        Returns
+        -------
+        list of json data
+
+        """
+        path = ('raob.py?ts={time:%Y%m%d%H}00&station={stid}').format(time=time, stid=site_id)
+        resp = self.get_path(path)
+        json_data = json.loads(resp.text)['profiles'][0]['profile']
+
+        # See if the return is valid, but has no data
+        if not json_data:
+            raise ValueError('No data available for {time:%Y-%m-%d %HZ} '
+                             'for station {stid}.'.format(time=time, stid=site_id))
+        return json_data

--- a/siphon/tests/fixtures/iastate_high_alt_sounding
+++ b/siphon/tests/fixtures/iastate_high_alt_sounding
@@ -1,0 +1,179 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.1+36.gd605722.dirty)]
+    method: GET
+    uri: http://mesonet.agron.iastate.edu/json/raob.py?ts=201012091200&station=BOI
+  response:
+    body: {string: '{"profiles": [{"profile": [{"dwpc": null, "pres": 1000.0, "sknt":
+        null, "drct": null, "tmpc": null, "hght": 189.0}, {"dwpc": null, "pres": 925.0,
+        "sknt": null, "drct": null, "tmpc": null, "hght": 818.0}, {"dwpc": -0.2, "pres":
+        919.0, "sknt": 3.0, "drct": 240.0, "tmpc": -0.1, "hght": 871.0}, {"dwpc":
+        0.9, "pres": 909.0, "sknt": null, "drct": null, "tmpc": 1.2, "hght": 958.0},
+        {"dwpc": 3.9, "pres": 890.0, "sknt": null, "drct": null, "tmpc": 5.4, "hght":
+        1129.0}, {"dwpc": null, "pres": 880.2, "sknt": 7.0, "drct": 155.0, "tmpc":
+        null, "hght": 1219.0}, {"dwpc": 1.9, "pres": 879.0, "sknt": null, "drct":
+        null, "tmpc": 5.0, "hght": 1230.0}, {"dwpc": 1.9, "pres": 862.0, "sknt": null,
+        "drct": null, "tmpc": 4.8, "hght": 1389.0}, {"dwpc": 1.1, "pres": 850.0, "sknt":
+        2.0, "drct": 250.0, "tmpc": 3.8, "hght": 1509.0}, {"dwpc": 1.0, "pres": 839.0,
+        "sknt": null, "drct": null, "tmpc": 3.0, "hght": 1614.0}, {"dwpc": -2.3, "pres":
+        818.0, "sknt": null, "drct": null, "tmpc": 1.8, "hght": 1818.0}, {"dwpc":
+        null, "pres": 817.0, "sknt": 11.0, "drct": 295.0, "tmpc": null, "hght": 1828.0},
+        {"dwpc": 0.0, "pres": 803.0, "sknt": null, "drct": null, "tmpc": 0.4, "hght":
+        1966.0}, {"dwpc": null, "pres": 786.3, "sknt": 14.0, "drct": 265.0, "tmpc":
+        null, "hght": 2133.0}, {"dwpc": -3.1, "pres": 758.0, "sknt": null, "drct":
+        null, "tmpc": -3.1, "hght": 2424.0}, {"dwpc": null, "pres": 756.7, "sknt":
+        18.0, "drct": 260.0, "tmpc": null, "hght": 2438.0}, {"dwpc": -6.4, "pres":
+        732.0, "sknt": null, "drct": null, "tmpc": -4.3, "hght": 2699.0}, {"dwpc":
+        null, "pres": 728.0, "sknt": 20.0, "drct": 255.0, "tmpc": null, "hght": 2743.0},
+        {"dwpc": -9.6, "pres": 700.0, "sknt": 27.0, "drct": 260.0, "tmpc": -7.5, "hght":
+        3056.0}, {"dwpc": -13.1, "pres": 668.0, "sknt": null, "drct": null, "tmpc":
+        -10.9, "hght": 3417.0}, {"dwpc": -13.6, "pres": 656.0, "sknt": null, "drct":
+        null, "tmpc": -12.3, "hght": 3555.0}, {"dwpc": -15.6, "pres": 652.0, "sknt":
+        null, "drct": null, "tmpc": -13.1, "hght": 3602.0}, {"dwpc": null, "pres":
+        647.3, "sknt": 35.0, "drct": 265.0, "tmpc": null, "hght": 3657.0}, {"dwpc":
+        -17.4, "pres": 646.0, "sknt": null, "drct": null, "tmpc": -12.9, "hght": 3672.0},
+        {"dwpc": -22.7, "pres": 641.0, "sknt": null, "drct": null, "tmpc": -12.7,
+        "hght": 3731.0}, {"dwpc": -25.9, "pres": 631.0, "sknt": null, "drct": null,
+        "tmpc": -13.9, "hght": 3850.0}, {"dwpc": -32.1, "pres": 625.0, "sknt": null,
+        "drct": null, "tmpc": -14.1, "hght": 3922.0}, {"dwpc": -34.7, "pres": 616.0,
+        "sknt": null, "drct": null, "tmpc": -14.7, "hght": 4032.0}, {"dwpc": -38.1,
+        "pres": 611.0, "sknt": null, "drct": null, "tmpc": -14.1, "hght": 4094.0},
+        {"dwpc": -50.5, "pres": 606.0, "sknt": null, "drct": null, "tmpc": -14.5,
+        "hght": 4156.0}, {"dwpc": null, "pres": 598.0, "sknt": null, "drct": null,
+        "tmpc": -14.7, "hght": 4256.0}, {"dwpc": null, "pres": 597.1, "sknt": 42.0,
+        "drct": 270.0, "tmpc": null, "hght": 4267.0}, {"dwpc": null, "pres": 550.5,
+        "sknt": 55.0, "drct": 265.0, "tmpc": null, "hght": 4876.0}, {"dwpc": null,
+        "pres": 546.0, "sknt": null, "drct": null, "tmpc": -18.3, "hght": 4938.0},
+        {"dwpc": null, "pres": 518.0, "sknt": null, "drct": null, "tmpc": -19.3, "hght":
+        5329.0}, {"dwpc": null, "pres": 507.5, "sknt": 61.0, "drct": 275.0, "tmpc":
+        null, "hght": 5486.0}, {"dwpc": null, "pres": 500.0, "sknt": 62.0, "drct":
+        275.0, "tmpc": -20.9, "hght": 5600.0}, {"dwpc": null, "pres": 467.0, "sknt":
+        69.0, "drct": 270.0, "tmpc": null, "hght": 6096.0}, {"dwpc": null, "pres":
+        437.0, "sknt": null, "drct": null, "tmpc": -27.7, "hght": 6579.0}, {"dwpc":
+        null, "pres": 433.0, "sknt": null, "drct": null, "tmpc": -27.3, "hght": 6645.0},
+        {"dwpc": null, "pres": 400.0, "sknt": 89.0, "drct": 275.0, "tmpc": -28.7,
+        "hght": 7210.0}, {"dwpc": null, "pres": 395.0, "sknt": null, "drct": null,
+        "tmpc": -28.7, "hght": 7300.0}, {"dwpc": -69.7, "pres": 394.0, "sknt": null,
+        "drct": null, "tmpc": -28.7, "hght": 7318.0}, {"dwpc": null, "pres": 377.4,
+        "sknt": 97.0, "drct": 280.0, "tmpc": null, "hght": 7620.0}, {"dwpc": -63.5,
+        "pres": 337.0, "sknt": null, "drct": null, "tmpc": -37.5, "hght": 8413.0},
+        {"dwpc": null, "pres": 302.9, "sknt": 104.0, "drct": 280.0, "tmpc": null,
+        "hght": 9144.0}, {"dwpc": -59.3, "pres": 300.0, "sknt": 104.0, "drct": 280.0,
+        "tmpc": -44.3, "hght": 9210.0}, {"dwpc": -59.1, "pres": 297.0, "sknt": null,
+        "drct": null, "tmpc": -45.1, "hght": 9277.0}, {"dwpc": -66.5, "pres": 250.0,
+        "sknt": 108.0, "drct": 280.0, "tmpc": -54.5, "hght": 10410.0}, {"dwpc": -67.5,
+        "pres": 246.0, "sknt": null, "drct": null, "tmpc": -55.5, "hght": 10513.0},
+        {"dwpc": null, "pres": 240.0, "sknt": 113.0, "drct": 280.0, "tmpc": null,
+        "hght": 10668.0}, {"dwpc": null, "pres": 235.0, "sknt": 113.0, "drct": 280.0,
+        "tmpc": null, "hght": 10799.0}, {"dwpc": null, "pres": 217.7, "sknt": 111.0,
+        "drct": 280.0, "tmpc": null, "hght": 11277.0}, {"dwpc": -71.5, "pres": 204.0,
+        "sknt": null, "drct": null, "tmpc": -60.5, "hght": 11683.0}, {"dwpc": -72.1,
+        "pres": 200.0, "sknt": 92.0, "drct": 280.0, "tmpc": -61.1, "hght": 11810.0},
+        {"dwpc": null, "pres": 197.5, "sknt": 87.0, "drct": 280.0, "tmpc": null, "hght":
+        11887.0}, {"dwpc": -74.5, "pres": 183.0, "sknt": null, "drct": null, "tmpc":
+        -62.5, "hght": 12358.0}, {"dwpc": null, "pres": 170.3, "sknt": 96.0, "drct":
+        275.0, "tmpc": null, "hght": 12801.0}, {"dwpc": -73.7, "pres": 169.0, "sknt":
+        null, "drct": null, "tmpc": -61.7, "hght": 12848.0}, {"dwpc": -74.5, "pres":
+        164.0, "sknt": null, "drct": null, "tmpc": -62.5, "hght": 13033.0}, {"dwpc":
+        -72.9, "pres": 155.0, "sknt": null, "drct": null, "tmpc": -60.9, "hght": 13382.0},
+        {"dwpc": -73.3, "pres": 150.0, "sknt": 70.0, "drct": 280.0, "tmpc": -61.3,
+        "hght": 13590.0}, {"dwpc": null, "pres": 147.0, "sknt": 65.0, "drct": 275.0,
+        "tmpc": null, "hght": 13716.0}, {"dwpc": -72.3, "pres": 146.0, "sknt": null,
+        "drct": null, "tmpc": -60.3, "hght": 13758.0}, {"dwpc": -74.9, "pres": 128.0,
+        "sknt": null, "drct": null, "tmpc": -61.9, "hght": 14573.0}, {"dwpc": -73.9,
+        "pres": 123.0, "sknt": null, "drct": null, "tmpc": -60.9, "hght": 14819.0},
+        {"dwpc": -74.1, "pres": 119.0, "sknt": null, "drct": null, "tmpc": -61.1,
+        "hght": 15024.0}, {"dwpc": -72.7, "pres": 116.0, "sknt": null, "drct": null,
+        "tmpc": -59.7, "hght": 15183.0}, {"dwpc": -71.9, "pres": 115.0, "sknt": null,
+        "drct": null, "tmpc": -57.9, "hght": 15237.0}, {"dwpc": null, "pres": 114.9,
+        "sknt": 68.0, "drct": 275.0, "tmpc": null, "hght": 15240.0}, {"dwpc": -71.7,
+        "pres": 113.0, "sknt": null, "drct": null, "tmpc": -57.7, "hght": 15347.0},
+        {"dwpc": -73.1, "pres": 107.0, "sknt": null, "drct": null, "tmpc": -59.1,
+        "hght": 15689.0}, {"dwpc": -75.1, "pres": 100.0, "sknt": 32.0, "drct": 285.0,
+        "tmpc": -62.1, "hght": 16110.0}, {"dwpc": -76.9, "pres": 90.8, "sknt": null,
+        "drct": null, "tmpc": -63.9, "hght": 16702.0}, {"dwpc": null, "pres": 89.9,
+        "sknt": 55.0, "drct": 285.0, "tmpc": null, "hght": 16764.0}, {"dwpc": null,
+        "pres": 85.5, "sknt": 35.0, "drct": 270.0, "tmpc": null, "hght": 17068.0},
+        {"dwpc": -76.7, "pres": 82.6, "sknt": null, "drct": null, "tmpc": -62.7, "hght":
+        17282.0}, {"dwpc": -75.3, "pres": 80.1, "sknt": null, "drct": null, "tmpc":
+        -61.3, "hght": 17472.0}, {"dwpc": null, "pres": 77.5, "sknt": 52.0, "drct":
+        260.0, "tmpc": null, "hght": 17678.0}, {"dwpc": -70.7, "pres": 76.6, "sknt":
+        null, "drct": null, "tmpc": -55.7, "hght": 17752.0}, {"dwpc": null, "pres":
+        73.9, "sknt": 45.0, "drct": 285.0, "tmpc": null, "hght": 17983.0}, {"dwpc":
+        null, "pres": 70.5, "sknt": 24.0, "drct": 290.0, "tmpc": null, "hght": 18288.0},
+        {"dwpc": -70.5, "pres": 70.0, "sknt": 28.0, "drct": 290.0, "tmpc": -54.5,
+        "hght": 18330.0}, {"dwpc": -70.5, "pres": 68.5, "sknt": null, "drct": null,
+        "tmpc": -53.5, "hght": 18469.0}, {"dwpc": null, "pres": 67.2, "sknt": 12.0,
+        "drct": 250.0, "tmpc": null, "hght": 18592.0}, {"dwpc": -75.1, "pres": 60.8,
+        "sknt": null, "drct": null, "tmpc": -59.1, "hght": 19224.0}, {"dwpc": null,
+        "pres": 58.1, "sknt": 16.0, "drct": 315.0, "tmpc": null, "hght": 19507.0},
+        {"dwpc": null, "pres": 55.3, "sknt": 19.0, "drct": 330.0, "tmpc": null, "hght":
+        19812.0}, {"dwpc": null, "pres": 52.7, "sknt": 21.0, "drct": 310.0, "tmpc":
+        null, "hght": 20116.0}, {"dwpc": -77.3, "pres": 51.9, "sknt": null, "drct":
+        null, "tmpc": -61.3, "hght": 20208.0}, {"dwpc": -76.5, "pres": 50.9, "sknt":
+        null, "drct": null, "tmpc": -59.5, "hght": 20329.0}, {"dwpc": -77.5, "pres":
+        50.0, "sknt": 9.0, "drct": 345.0, "tmpc": -60.5, "hght": 20450.0}, {"dwpc":
+        null, "pres": 47.8, "sknt": 13.0, "drct": 335.0, "tmpc": null, "hght": 20726.0},
+        {"dwpc": -79.7, "pres": 46.1, "sknt": null, "drct": null, "tmpc": -63.7, "hght":
+        20950.0}, {"dwpc": null, "pres": 43.3, "sknt": 20.0, "drct": 300.0, "tmpc":
+        null, "hght": 21336.0}, {"dwpc": -76.3, "pres": 43.1, "sknt": null, "drct":
+        null, "tmpc": -59.3, "hght": 21366.0}, {"dwpc": null, "pres": 41.2, "sknt":
+        11.0, "drct": 270.0, "tmpc": null, "hght": 21640.0}, {"dwpc": -77.3, "pres":
+        40.3, "sknt": null, "drct": null, "tmpc": -60.3, "hght": 21784.0}, {"dwpc":
+        null, "pres": 39.3, "sknt": 16.0, "drct": 295.0, "tmpc": null, "hght": 21945.0},
+        {"dwpc": -76.1, "pres": 38.5, "sknt": null, "drct": null, "tmpc": -58.1, "hght":
+        22069.0}, {"dwpc": -76.1, "pres": 35.9, "sknt": null, "drct": null, "tmpc":
+        -57.1, "hght": 22509.0}, {"dwpc": null, "pres": 35.6, "sknt": 14.0, "drct":
+        310.0, "tmpc": null, "hght": 22555.0}, {"dwpc": null, "pres": 33.9, "sknt":
+        2.0, "drct": 300.0, "tmpc": null, "hght": 22860.0}, {"dwpc": -76.7, "pres":
+        33.9, "sknt": null, "drct": null, "tmpc": -58.7, "hght": 22869.0}, {"dwpc":
+        null, "pres": 30.9, "sknt": 17.0, "drct": 325.0, "tmpc": null, "hght": 23469.0},
+        {"dwpc": -77.3, "pres": 30.0, "sknt": 12.0, "drct": 340.0, "tmpc": -58.3,
+        "hght": 23650.0}, {"dwpc": null, "pres": 29.4, "sknt": 11.0, "drct": 340.0,
+        "tmpc": null, "hght": 23774.0}, {"dwpc": null, "pres": 26.7, "sknt": 9.0,
+        "drct": 0.0, "tmpc": null, "hght": 24384.0}, {"dwpc": -78.5, "pres": 25.7,
+        "sknt": null, "drct": null, "tmpc": -58.5, "hght": 24620.0}, {"dwpc": -78.5,
+        "pres": 24.0, "sknt": null, "drct": null, "tmpc": -56.5, "hght": 25051.0},
+        {"dwpc": null, "pres": 23.1, "sknt": 2.0, "drct": 200.0, "tmpc": null, "hght":
+        25298.0}, {"dwpc": -79.1, "pres": 22.4, "sknt": null, "drct": null, "tmpc":
+        -57.1, "hght": 25487.0}, {"dwpc": null, "pres": 21.2, "sknt": null, "drct":
+        null, "tmpc": -54.7, "hght": 25836.0}, {"dwpc": null, "pres": 21.0, "sknt":
+        11.0, "drct": 325.0, "tmpc": null, "hght": 25908.0}, {"dwpc": null, "pres":
+        20.0, "sknt": 12.0, "drct": 355.0, "tmpc": -54.9, "hght": 26210.0}, {"dwpc":
+        null, "pres": 18.7, "sknt": null, "drct": null, "tmpc": -54.1, "hght": 26639.0},
+        {"dwpc": null, "pres": 17.3, "sknt": 13.0, "drct": 355.0, "tmpc": null, "hght":
+        27127.0}, {"dwpc": null, "pres": 16.5, "sknt": 11.0, "drct": 340.0, "tmpc":
+        null, "hght": 27432.0}, {"dwpc": null, "pres": 16.2, "sknt": null, "drct":
+        null, "tmpc": -54.1, "hght": 27557.0}, {"dwpc": null, "pres": 15.8, "sknt":
+        15.0, "drct": 5.0, "tmpc": null, "hght": 27736.0}, {"dwpc": null, "pres":
+        14.3, "sknt": 2.0, "drct": 310.0, "tmpc": null, "hght": 28346.0}, {"dwpc":
+        null, "pres": 14.1, "sknt": null, "drct": null, "tmpc": -56.1, "hght": 28441.0},
+        {"dwpc": null, "pres": 12.4, "sknt": 14.0, "drct": 340.0, "tmpc": null, "hght":
+        29260.0}, {"dwpc": null, "pres": 11.8, "sknt": 26.0, "drct": 345.0, "tmpc":
+        null, "hght": 29565.0}, {"dwpc": null, "pres": 11.7, "sknt": null, "drct":
+        null, "tmpc": -53.9, "hght": 29630.0}, {"dwpc": null, "pres": 10.5, "sknt":
+        null, "drct": null, "tmpc": -55.7, "hght": 30320.0}, {"dwpc": null, "pres":
+        10.2, "sknt": 16.0, "drct": 310.0, "tmpc": null, "hght": 30480.0}, {"dwpc":
+        null, "pres": 10.0, "sknt": 21.0, "drct": 320.0, "tmpc": -54.3, "hght": 30640.0},
+        {"dwpc": null, "pres": 9.5, "sknt": null, "drct": null, "tmpc": -52.7, "hght":
+        30969.0}, {"dwpc": null, "pres": 8.3, "sknt": null, "drct": null, "tmpc":
+        -53.9, "hght": 31836.0}, {"dwpc": null, "pres": 7.7, "sknt": 20.0, "drct":
+        310.0, "tmpc": null, "hght": 32308.0}, {"dwpc": -88.9, "pres": 7.5, "sknt":
+        null, "drct": null, "tmpc": -56.9, "hght": 32480.0}], "station": "KBOI", "valid":
+        "2010-12-09T12:00:00Z"}]}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [Keep-Alive]
+      Content-Type: [application/json]
+      Date: ['Mon, 19 Mar 2018 19:33:11 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_fcgid/2.3.9
+          mod_wsgi/4.6.2 Python/2.7]
+      X-IEM-ServerID: [iemvs102.local]
+    status: {code: 200, message: OK}
+version: 1

--- a/siphon/tests/fixtures/iastate_sounding
+++ b/siphon/tests/fixtures/iastate_sounding
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.6.1+36.gd605722.dirty)]
+    method: GET
+    uri: http://mesonet.agron.iastate.edu/json/raob.py?ts=199905040000&station=OUN
+  response:
+    body: {string: '{"profiles": [{"profile": [{"dwpc": null, "pres": 1000.0, "sknt":
+        null, "drct": null, "tmpc": null, "hght": 0.0}, {"dwpc": 19.1, "pres": 959.0,
+        "sknt": 18.0, "drct": 160.0, "tmpc": 22.3, "hght": 362.0}, {"dwpc": 17.7,
+        "pres": 952.3, "sknt": 22.0, "drct": 161.0, "tmpc": 22.2, "hght": 418.0},
+        {"dwpc": 17.1, "pres": 925.0, "sknt": 38.0, "drct": 164.0, "tmpc": 19.8, "hght":
+        671.0}, {"dwpc": null, "pres": 921.7, "sknt": 40.0, "drct": 164.0, "tmpc":
+        null, "hght": 702.0}, {"dwpc": 16.8, "pres": 892.4, "sknt": 38.0, "drct":
+        178.0, "tmpc": 18.0, "hght": 980.0}, {"dwpc": null, "pres": 889.6, "sknt":
+        38.0, "drct": 179.0, "tmpc": null, "hght": 1007.0}, {"dwpc": 15.1, "pres":
+        872.7, "sknt": 38.0, "drct": 187.0, "tmpc": 18.2, "hght": 1172.0}, {"dwpc":
+        null, "pres": 859.6, "sknt": 38.0, "drct": 194.0, "tmpc": null, "hght": 1301.0},
+        {"dwpc": 12.6, "pres": 850.0, "sknt": 38.0, "drct": 196.0, "tmpc": 17.1, "hght":
+        1397.0}, {"dwpc": null, "pres": 830.3, "sknt": 37.0, "drct": 201.0, "tmpc":
+        null, "hght": 1597.0}, {"dwpc": 5.3, "pres": 813.8, "sknt": 37.0, "drct":
+        205.0, "tmpc": 15.4, "hght": 1768.0}, {"dwpc": null, "pres": 801.0, "sknt":
+        37.0, "drct": 209.0, "tmpc": null, "hght": 1902.0}, {"dwpc": -8.5, "pres":
+        797.8, "sknt": 38.0, "drct": 210.0, "tmpc": 15.8, "hght": 1936.0}, {"dwpc":
+        -11.0, "pres": 789.9, "sknt": 39.0, "drct": 211.0, "tmpc": 15.6, "hght": 2021.0},
+        {"dwpc": null, "pres": 772.0, "sknt": 42.0, "drct": 215.0, "tmpc": null, "hght":
+        2213.0}, {"dwpc": null, "pres": 743.0, "sknt": 42.0, "drct": 218.0, "tmpc":
+        null, "hght": 2533.0}, {"dwpc": -13.6, "pres": 726.2, "sknt": 40.0, "drct":
+        219.0, "tmpc": 9.6, "hght": 2726.0}, {"dwpc": null, "pres": 715.6, "sknt":
+        39.0, "drct": 220.0, "tmpc": null, "hght": 2846.0}, {"dwpc": -10.3, "pres":
+        700.0, "sknt": 37.0, "drct": 221.0, "tmpc": 7.0, "hght": 3028.0}, {"dwpc":
+        null, "pres": 688.6, "sknt": 36.0, "drct": 221.0, "tmpc": null, "hght": 3162.0},
+        {"dwpc": -13.4, "pres": 671.9, "sknt": 37.0, "drct": 220.0, "tmpc": 4.4, "hght":
+        3363.0}, {"dwpc": null, "pres": 660.5, "sknt": 37.0, "drct": 219.0, "tmpc":
+        null, "hght": 3502.0}, {"dwpc": -16.4, "pres": 654.8, "sknt": 37.0, "drct":
+        220.0, "tmpc": 2.2, "hght": 3572.0}, {"dwpc": -12.6, "pres": 638.4, "sknt":
+        38.0, "drct": 222.0, "tmpc": 0.2, "hght": 3776.0}, {"dwpc": null, "pres":
+        634.0, "sknt": 38.0, "drct": 223.0, "tmpc": null, "hght": 3831.0}, {"dwpc":
+        null, "pres": 612.6, "sknt": 37.0, "drct": 228.0, "tmpc": null, "hght": 4104.0},
+        {"dwpc": -15.8, "pres": 602.2, "sknt": 39.0, "drct": 227.0, "tmpc": -4.4,
+        "hght": 4240.0}, {"dwpc": null, "pres": 592.6, "sknt": 41.0, "drct": 227.0,
+        "tmpc": null, "hght": 4365.0}, {"dwpc": null, "pres": 573.8, "sknt": 37.0,
+        "drct": 227.0, "tmpc": null, "hght": 4616.0}, {"dwpc": null, "pres": 555.6,
+        "sknt": 38.0, "drct": 220.0, "tmpc": null, "hght": 4867.0}, {"dwpc": -14.6,
+        "pres": 550.3, "sknt": 41.0, "drct": 220.0, "tmpc": -10.1, "hght": 4942.0},
+        {"dwpc": null, "pres": 536.8, "sknt": 47.0, "drct": 219.0, "tmpc": null, "hght":
+        5132.0}, {"dwpc": null, "pres": 518.1, "sknt": 40.0, "drct": 222.0, "tmpc":
+        null, "hght": 5403.0}, {"dwpc": -18.8, "pres": 500.0, "sknt": 36.0, "drct":
+        227.0, "tmpc": -14.8, "hght": 5674.0}, {"dwpc": null, "pres": 478.8, "sknt":
+        41.0, "drct": 232.0, "tmpc": null, "hght": 5998.0}, {"dwpc": null, "pres":
+        458.5, "sknt": 47.0, "drct": 235.0, "tmpc": null, "hght": 6323.0}, {"dwpc":
+        -22.8, "pres": 448.7, "sknt": 47.0, "drct": 235.0, "tmpc": -20.1, "hght":
+        6485.0}, {"dwpc": null, "pres": 437.6, "sknt": 48.0, "drct": 235.0, "tmpc":
+        null, "hght": 6668.0}, {"dwpc": null, "pres": 416.3, "sknt": 43.0, "drct":
+        235.0, "tmpc": null, "hght": 7033.0}, {"dwpc": -30.1, "pres": 400.0, "sknt":
+        40.0, "drct": 237.0, "tmpc": -26.7, "hght": 7326.0}, {"dwpc": null, "pres":
+        395.5, "sknt": 39.0, "drct": 237.0, "tmpc": null, "hght": 7406.0}, {"dwpc":
+        null, "pres": 373.7, "sknt": 40.0, "drct": 237.0, "tmpc": null, "hght": 7811.0},
+        {"dwpc": -35.5, "pres": 365.3, "sknt": 41.0, "drct": 237.0, "tmpc": -32.1,
+        "hght": 7973.0}, {"dwpc": null, "pres": 355.1, "sknt": 42.0, "drct": 237.0,
+        "tmpc": null, "hght": 8170.0}, {"dwpc": null, "pres": 338.8, "sknt": 47.0,
+        "drct": 235.0, "tmpc": null, "hght": 8499.0}, {"dwpc": -41.1, "pres": 335.6,
+        "sknt": 46.0, "drct": 235.0, "tmpc": -37.1, "hght": 8565.0}, {"dwpc": -42.7,
+        "pres": 327.0, "sknt": 44.0, "drct": 236.0, "tmpc": -38.7, "hght": 8744.0},
+        {"dwpc": null, "pres": 325.3, "sknt": 43.0, "drct": 236.0, "tmpc": null, "hght":
+        8780.0}, {"dwpc": -44.1, "pres": 317.7, "sknt": 37.0, "drct": 238.0, "tmpc":
+        -40.1, "hght": 8942.0}, {"dwpc": null, "pres": 316.4, "sknt": 36.0, "drct":
+        238.0, "tmpc": null, "hght": 8970.0}, {"dwpc": null, "pres": 303.7, "sknt":
+        37.0, "drct": 241.0, "tmpc": null, "hght": 9247.0}, {"dwpc": -47.5, "pres":
+        300.0, "sknt": 38.0, "drct": 244.0, "tmpc": -43.5, "hght": 9330.0}, {"dwpc":
+        null, "pres": 291.8, "sknt": 40.0, "drct": 250.0, "tmpc": null, "hght": 9515.0},
+        {"dwpc": null, "pres": 280.4, "sknt": 60.0, "drct": 245.0, "tmpc": null, "hght":
+        9780.0}, {"dwpc": -51.4, "pres": 278.2, "sknt": 62.0, "drct": 245.0, "tmpc":
+        -47.2, "hght": 9833.0}, {"dwpc": null, "pres": 268.9, "sknt": 72.0, "drct":
+        244.0, "tmpc": null, "hght": 10055.0}, {"dwpc": -54.0, "pres": 266.7, "sknt":
+        71.0, "drct": 245.0, "tmpc": -50.0, "hght": 10110.0}, {"dwpc": null, "pres":
+        258.9, "sknt": 69.0, "drct": 248.0, "tmpc": null, "hght": 10302.0}, {"dwpc":
+        -56.6, "pres": 250.5, "sknt": null, "drct": null, "tmpc": -52.4, "hght": 10517.0}],
+        "station": "KOUN", "valid": "1999-05-04T00:00:00Z"}]}'}
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [Keep-Alive]
+      Content-Type: [application/json]
+      Date: ['Mon, 19 Mar 2018 19:32:56 GMT']
+      Keep-Alive: ['timeout=5, max=100']
+      Server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_fcgid/2.3.9
+          mod_wsgi/4.6.2 Python/2.7]
+      X-IEM-ServerID: [iemvs108.local]
+    status: {code: 200, message: OK}
+version: 1

--- a/siphon/tests/test_iastate.py
+++ b/siphon/tests/test_iastate.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2017 University Corporation for Atmospheric Research/Unidata.
+# Distributed under the terms of the MIT License.
+# SPDX-License-Identifier: MIT
+"""Test Iowa State upper air dataset access."""
+
+from datetime import datetime
+
+from numpy.testing import assert_almost_equal
+
+from siphon.simplewebservice.iastate import IAStateUpperAir
+from siphon.testing import get_recorder
+
+
+recorder = get_recorder(__file__)
+
+
+@recorder.use_cassette('iastate_sounding')
+def test_iastate():
+    """Test that we are properly parsing data from the Iowa State archive."""
+    df = IAStateUpperAir.request_data(datetime(1999, 5, 4, 0), 'OUN')
+
+    assert_almost_equal(df['pressure'][6], 872.7, 2)
+    assert_almost_equal(df['height'][6], 1172.0, 2)
+    assert_almost_equal(df['temperature'][6], 18.2, 2)
+    assert_almost_equal(df['dewpoint'][6], 15.1, 2)
+    assert_almost_equal(df['u_wind'][6], 4.631, 2)
+    assert_almost_equal(df['v_wind'][6], 37.716, 2)
+    assert_almost_equal(df['speed'][6], 38.0, 1)
+    assert_almost_equal(df['direction'][6], 187.0, 1)
+
+    assert(df.units['pressure'] == 'hPa')
+    assert(df.units['height'] == 'meter')
+    assert(df.units['temperature'] == 'degC')
+    assert(df.units['dewpoint'] == 'degC')
+    assert(df.units['u_wind'] == 'knot')
+    assert(df.units['v_wind'] == 'knot')
+    assert(df.units['speed'] == 'knot')
+    assert(df.units['direction'] == 'degrees')
+
+
+@recorder.use_cassette('iastate_high_alt_sounding')
+def test_high_alt_iastate():
+    """Test Iowa State data that starts at pressure less than 925 hPa."""
+    df = IAStateUpperAir.request_data(datetime(2010, 12, 9, 12), 'BOI')
+
+    assert_almost_equal(df['pressure'][0], 919.0, 2)
+    assert_almost_equal(df['height'][0], 871.0, 2)
+    assert_almost_equal(df['temperature'][0], -0.1, 2)
+    assert_almost_equal(df['dewpoint'][0], -0.2, 2)
+    assert_almost_equal(df['u_wind'][0], 2.598, 2)
+    assert_almost_equal(df['v_wind'][0], 1.500, 2)
+    assert_almost_equal(df['speed'][0], 3.0, 1)
+    assert_almost_equal(df['direction'][0], 240.0, 1)

--- a/siphon/tests/test_wyoming.py
+++ b/siphon/tests/test_wyoming.py
@@ -16,7 +16,7 @@ recorder = get_recorder(__file__)
 
 @recorder.use_cassette('wyoming_sounding')
 def test_wyoming():
-    """Test that we are properly parsing data from the wyoming archive."""
+    """Test that we are properly parsing data from the Wyoming archive."""
     df = WyomingUpperAir.request_data(datetime(1999, 5, 4, 0), 'OUN')
 
     assert_almost_equal(df['pressure'][5], 867.9, 2)
@@ -49,3 +49,5 @@ def test_high_alt_wyoming():
     assert_almost_equal(df['dewpoint'][2], 3.9, 2)
     assert_almost_equal(df['u_wind'][2], -0.42, 2)
     assert_almost_equal(df['v_wind'][2], 5.99, 2)
+    assert_almost_equal(df['speed'][2], 6.0, 1)
+    assert_almost_equal(df['direction'][2], 176.0, 1)


### PR DESCRIPTION
Closes #156 by porting the IA State upper air data functionality over from MetPy. Also fixes a typo in Wyoming and lack of test coverage there. I'll work on #189 for both Wyoming and Iowa after this.