### PR TITLE
MNT: Fix with xarray 0.10.2 (Fixes #192)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,6 @@ dependencies:
   - flake8-quotes
   - pep8-naming
   - matplotlib
-  - xarray
+  - xarray >=0.10.2
   - cartopy
   - beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
                  'flake8-copyright', 'flake8-docstrings', 'flake8-import-order',
                  'flake8-mutable', 'flake8-pep3101', 'flake8-print', 'flake8-quotes',
                  'pep8-naming',
-                 'vcrpy~=1.5,!=1.7.0,!=1.7.1,!=1.7.2,!=1.7.3', 'xarray>=0.6'],
+                 'vcrpy~=1.5,!=1.7.0,!=1.7.1,!=1.7.2,!=1.7.3', 'xarray>=0.10.2'],
         'doc': ['sphinx>=1.3,!=1.6.4', 'sphinx-gallery', 'doc8', 'recommonmark'],
         # SciPy needed for cartopy; we don't use cartopy[plotting] because
         # that will pull in GDAL.

--- a/siphon/cdmr/xarray_support.py
+++ b/siphon/cdmr/xarray_support.py
@@ -29,9 +29,15 @@ class CDMArrayWrapper(BackendArray):
 
     def __getitem__(self, item):
         """Wrap getitem around the data."""
-        item = indexing.unwrap_explicit_indexer(
-            item, self, allow=(indexing.BasicIndexer, indexing.OuterIndexer))
-        return self.get_array()[item]
+        item, np_inds = indexing.decompose_indexer(item, self.shape,
+                                                   indexing.IndexingSupport.BASIC)
+        with self.datastore:
+            array = self.get_array()[item.tuple]
+
+        if len(np_inds.tuple) > 0:
+            array = indexing.NumpyIndexingAdapter(array)[np_inds]
+
+        return array
 
 
 class CDMRemoteStore(AbstractDataStore):
@@ -45,7 +51,7 @@ class CDMRemoteStore(AbstractDataStore):
 
     def open_store_variable(self, name, var):
         """Turn CDMRemote variable into something like a numpy.ndarray."""
-        data = indexing.LazilyIndexedArray(CDMArrayWrapper(name, self))
+        data = indexing.LazilyOuterIndexedArray(CDMArrayWrapper(name, self))
         return Variable(var.dimensions, data, {a: getattr(var, a) for a in var.ncattrs()})
 
     def get_variables(self):


### PR DESCRIPTION
XArray reworked some of the classes that support our CDMRemote backend, so we need to update. This also means that this (admittedly under exposed) code only works with xarray >=0.10.2, so bump the requirements for it.