### PR TITLE
MNT: Remove calls to dict.keys()

### DIFF
--- a/examples/ncss/NCSS_Example.py
+++ b/examples/ncss/NCSS_Example.py
@@ -47,7 +47,7 @@ query.variables('Temperature_isobaric', 'Relative_humidity_isobaric')
 # this NetCDF data (using the `netCDF4` module). If we print out the variable names,
 # we see our requested variables, as well as a few others (more metadata information)
 data = ncss.get_data(query)
-list(data.variables.keys())
+list(data.variables)
 
 ###########################################
 # We'll pull out the variables we want to use, as well as the pressure values. To get the

--- a/examples/ncss/NCSS_Timeseries_Examples.py
+++ b/examples/ncss/NCSS_Timeseries_Examples.py
@@ -48,7 +48,7 @@ query.variables('Temperature_isobaric').accept('netcdf')
 # this NetCDF data (using the `netCDF4` module). If we print out the variable names, we
 # see our requested variables, as well as a few others (more metadata information)
 data = ncss.get_data(query)
-list(data.variables.keys())
+list(data.variables)
 
 ###########################################
 # We'll pull out the temperature  and time variables.

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -262,7 +262,8 @@ class TDSCatalog(object):
         self.metadata = TDSCatalogMetadata(element, self.metadata).metadata
 
     def _process_datasets(self):
-        for dsName in list(self.datasets.keys()):
+        # Need to use list (of keys) because we modify the dict while iterating
+        for dsName in list(self.datasets):
             # check to see if dataset needs to have access urls created, if not,
             # remove the dataset
             has_url_path = self.datasets[dsName].url_path is not None

--- a/siphon/ncss.py
+++ b/siphon/ncss.py
@@ -57,7 +57,7 @@ class NCSS(HTTPEndPoint):
         meta_xml = self.get_path('dataset.xml').content
         root = ET.fromstring(meta_xml)
         self.metadata = NCSSDataset(root)
-        self.variables = set(self.metadata.variables.keys())
+        self.variables = set(self.metadata.variables)
 
     def query(self):
         """Return a new query for NCSS.
@@ -351,7 +351,7 @@ def parse_xml_dataset(elem, handle_units):
     # Group points by the contents of each point
     datasets = {}
     for p in points:
-        datasets.setdefault(tuple(p.keys()), []).append(p)
+        datasets.setdefault(tuple(p), []).append(p)
 
     all_units = combine_dicts(units)
     return [combine_xml_points(d, all_units, handle_units) for d in datasets.values()]

--- a/siphon/ncss_dataset.py
+++ b/siphon/ncss_dataset.py
@@ -137,7 +137,7 @@ class _Types(object):
                 val = val.split()
         else:
             increment_attrs = ['start', 'increment', 'npts']
-            element_attrs = list(element.attrib.keys())
+            element_attrs = list(element.attrib)
             increment_attrs.sort()
             element_attrs.sort()
             if increment_attrs == element_attrs:

--- a/siphon/radarserver.py
+++ b/siphon/radarserver.py
@@ -80,7 +80,7 @@ class RadarServer(HTTPEndPoint):
     def _get_metadata(self):
         ds_cat = TDSCatalog(self.url_path('dataset.xml'))
         self.metadata = ds_cat.metadata
-        self.variables = {k.split('/')[0] for k in self.metadata['variables'].keys()}
+        self.variables = {k.split('/')[0] for k in self.metadata['variables']}
         self._get_stations()
 
     def _get_stations(self, station_file='stations.xml'):


### PR DESCRIPTION
For most cases it's completely unnecessary and longer. Just iterate over the dict directly.