### PR TITLE
MNT: Improve logging set up

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -21,9 +21,8 @@ except ImportError:
 from .http_util import create_http_session, urlopen
 from .metadata import TDSCatalogMetadata
 
+logging.basicConfig(level=logging.ERROR)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.ERROR)
 
 
 class IndexableMapping(OrderedDict):

--- a/siphon/cdmr/coveragedataset.py
+++ b/siphon/cdmr/coveragedataset.py
@@ -10,9 +10,8 @@ import warnings
 from .cdmremotefeature import CDMRemoteFeature
 from .dataset import AttributeContainer
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.WARNING)
 
 
 def reindent_lines(new_leader, source):

--- a/siphon/cdmr/dataset.py
+++ b/siphon/cdmr/dataset.py
@@ -12,9 +12,8 @@ import logging
 from .cdmremote import CDMRemote
 from .ncstream import unpack_attribute, unpack_variable
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.WARNING)
 
 
 class AttributeContainer(object):

--- a/siphon/cdmr/ncstream.py
+++ b/siphon/cdmr/ncstream.py
@@ -25,9 +25,8 @@ MAGIC_ERR = b'\xab\xad\xba\xda'
 MAGIC_HEADERCOV = b'\xad\xed\xde\xda'
 MAGIC_DATACOV = b'\xab\xed\xde\xba'
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
-log.setLevel(logging.WARNING)
 
 
 #

--- a/siphon/metadata.py
+++ b/siphon/metadata.py
@@ -7,9 +7,8 @@ from __future__ import print_function
 
 import logging
 
+logging.basicConfig(level=logging.ERROR)
 log = logging.getLogger(__name__)
-log.setLevel(logging.ERROR)
-log.addHandler(logging.StreamHandler())
 
 xlink_href_attr = '{http://www.w3.org/1999/xlink}href'
 xlink_title_attr = '{http://www.w3.org/1999/xlink}title'

--- a/siphon/ncss_dataset.py
+++ b/siphon/ncss_dataset.py
@@ -10,9 +10,8 @@ import re
 
 import numpy as np
 
+logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
-log.setLevel(logging.WARNING)
-log.addHandler(logging.StreamHandler())
 
 
 def _without_namespace(tagname):

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -13,7 +13,6 @@ from siphon.testing import get_recorder
 
 log = logging.getLogger('siphon.catalog')
 log.setLevel(logging.WARNING)
-log.addHandler(logging.StreamHandler())
 
 recorder = get_recorder(__file__)
 


### PR DESCRIPTION
Instead of manually adding a stream handler, use `basicConfig()`, which sets up a default formatter and stream handler. It also allows us to set a default logging level, which makes it easier for users to override. It's not entirely the same as before, as we were setting different level for different modules. But at least in this case, user settings for logging will take precedence, regardless of whether they set it before or after they import siphon modules.