### PR TITLE
include <dataset> ID in siphon.Dataset

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -369,6 +369,10 @@ class Dataset(object):
 
         """
         self.name = element_node.attrib['name']
+        if 'ID' in element_node.attrib:
+            self.id = element_node.attrib['ID']
+        else:
+            self.id = self.name
         if 'urlPath' in element_node.attrib:
             self.url_path = element_node.attrib['urlPath']
         else:


### PR DESCRIPTION
The 'ID' attribute from THREDDS catalog is useful for some purposes and should be parsed