### PR TITLE
add case-insensitive strings and dicts for service types

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -135,12 +135,12 @@ class DatasetCollection(IndexableMapping):
     __repr__ = __str__
 
 
-def _try_lower(obj):
+def _try_lower(arg):
     try:
-        obj = obj.lower()
+        arg = arg.lower()
     except (TypeError, AttributeError, ValueError):
         pass
-    return obj
+    return arg
 
 
 class CaseInsensitiveStr(str):
@@ -179,6 +179,14 @@ class CaseInsensitiveStr(str):
         return str.__ne__(self._lowered, _try_lower(other))
 
 
+def _try_case_insensitive(arg):
+    try:
+        arg = CaseInsensitiveStr(arg)
+    except (TypeError, AttributeError, ValueError):
+        pass
+    return arg
+
+
 class CaseInsensitiveDict(dict):
     """Extend ``dict`` to use a case-insensitive key set."""
 
@@ -193,30 +201,26 @@ class CaseInsensitiveDict(dict):
 
     def __getitem__(self, key):
         """Return value from case-insensitive lookup of ``key``."""
-        return super(CaseInsensitiveDict, self).__getitem__(_try_lower(key))
+        return super(CaseInsensitiveDict, self).__getitem__(_try_case_insensitive(key))
 
     def __setitem__(self, key, value):
         """Set value with lowercase ``key``."""
-        super(CaseInsensitiveDict, self).__setitem__(_try_lower(key), value)
+        super(CaseInsensitiveDict, self).__setitem__(_try_case_insensitive(key), value)
 
     def __delitem__(self, key):
         """Delete value associated with case-insensitive lookup of ``key``."""
-        return super(CaseInsensitiveDict, self).__delitem__(_try_lower(key))
+        return super(CaseInsensitiveDict, self).__delitem__(_try_case_insensitive(key))
 
     def __contains__(self, key):
         """Return true if key set includes case-insensitive ``key``."""
-        return super(CaseInsensitiveDict, self).__contains__(_try_lower(key))
-
-    def get(self, key, *args, **kwargs):
-        """Return value from case-insensitive lookup of ``key``."""
-        return super(CaseInsensitiveDict, self).get(_try_lower(key), *args, **kwargs)
+        return super(CaseInsensitiveDict, self).__contains__(_try_case_insensitive(key))
 
     def _keys_to_lower(self):
         """Convert key set to lowercase."""
         for k in list(self.keys()):
             val = super(CaseInsensitiveDict, self).__getitem__(k)
             super(CaseInsensitiveDict, self).__delitem__(k)
-            self.__setitem__(_try_lower(k), val)
+            self.__setitem__(_try_case_insensitive(k), val)
 
 
 class TDSCatalog(object):

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -544,7 +544,7 @@ class Dataset(object):
         # types).
         if service_name in all_service_dict:
             service = all_service_dict[service_name]
-            if CaseInsensitiveStr(service.service_type) != CaseInsensitiveStr('Resolver'):
+            if service.service_type != 'Resolver':
                 # if service is a CompoundService, create access url
                 # for each SimpleService
                 if isinstance(service, CompoundService):
@@ -724,13 +724,13 @@ class SimpleService(object):
 
         """
         self.name = service_node.attrib['name']
-        self.service_type = service_node.attrib['serviceType']
+        self.service_type = CaseInsensitiveStr(service_node.attrib['serviceType'])
         self.base = service_node.attrib['base']
         self.access_urls = {}
 
     def is_resolver(self):
         """Return whether the service is a resolver service."""
-        return CaseInsensitiveStr(self.service_type) == 'Resolver'
+        return self.service_type == 'Resolver'
 
 
 class CompoundService(object):
@@ -758,7 +758,7 @@ class CompoundService(object):
 
         """
         self.name = service_node.attrib['name']
-        self.service_type = service_node.attrib['serviceType']
+        self.service_type = CaseInsensitiveStr(service_node.attrib['serviceType'])
         self.base = service_node.attrib['base']
         services = []
         subservices = 0

--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -18,8 +18,8 @@ except ImportError:
     # Python 3
     from urllib.parse import urljoin, urlparse
 
-from .http_util import create_http_session, urlopen
-from .metadata import TDSCatalogMetadata
+from siphon.http_util import create_http_session, urlopen
+from siphon.metadata import TDSCatalogMetadata
 
 logging.basicConfig(level=logging.ERROR)
 log = logging.getLogger(__name__)

--- a/siphon/tests/fixtures/thredds-test-default-5-0
+++ b/siphon/tests/fixtures/thredds-test-default-5-0
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Siphon (0.7.0+28.g20c017a.dirty)]
+    method: GET
+    uri: http://localhost:8081/thredds/catalog/catalog.xml
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<catalog xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\" name=\"THREDDS Server Default
+        Catalog : You must change this to fit your server!\" version=\"1.2\">\r\n
+        \ <service name=\"all\" serviceType=\"compound\" base=\"\">\r\n    <service
+        name=\"odap\" serviceType=\"OpenDAP\" base=\"/thredds/dodsC/\" />\r\n    <service
+        name=\"dap4\" serviceType=\"DAP4\" base=\"/thredds/dap4/\" />\r\n    <service
+        name=\"http\" serviceType=\"HTTPServer\" base=\"/thredds/fileServer/\" />\r\n
+        \   <service name=\"wcs\" serviceType=\"WCS\" base=\"/thredds/wcs/\" />\r\n
+        \   <service name=\"wms\" serviceType=\"WMS\" base=\"/thredds/wms/\" />\r\n
+        \   <service name=\"ncssGrid\" serviceType=\"NetcdfSubset\" base=\"/thredds/ncss/grid/\"
+        />\r\n    <service name=\"ncssPoint\" serviceType=\"NetcdfSubset\" base=\"/thredds/ncss/point/\"
+        />\r\n    <service name=\"cdmremote\" serviceType=\"CdmRemote\" base=\"/thredds/cdmremote/\"
+        />\r\n    <service name=\"cdmrFeature\" serviceType=\"CdmrFeature\" base=\"/thredds/cdmrfeature/grid/\"
+        />\r\n    <service name=\"iso\" serviceType=\"ISO\" base=\"/thredds/iso/\"
+        />\r\n    <service name=\"ncml\" serviceType=\"NCML\" base=\"/thredds/ncml/\"
+        />\r\n    <service name=\"uddc\" serviceType=\"UDDC\" base=\"/thredds/uddc/\"
+        />\r\n  </service>\r\n  <dataset name=\"Test Grid Dataset\" ID=\"testGrid\"
+        urlPath=\"test/crossSeamProjection.nc\">\r\n    <serviceName>all</serviceName>\r\n
+        \   <dataType>Grid</dataType>\r\n  </dataset>\r\n  <dataset name=\"Test Point
+        Dataset\" ID=\"testPoint\" urlPath=\"test/H.1.1.nc\">\r\n    <serviceName>all</serviceName>\r\n
+        \   <dataType>Point</dataType>\r\n  </dataset>\r\n  <dataset name=\"Test Station
+        Dataset\" ID=\"testStation\" urlPath=\"test/H.2.1.1.nc\">\r\n    <serviceName>all</serviceName>\r\n
+        \   <dataType>Point</dataType>\r\n  </dataset>\r\n  <catalogRef xlink:href=\"/thredds/catalog/testAll/catalog.xml\"
+        xlink:title=\"Test all files in a directory\" ID=\"testDatasetScan\" name=\"Test
+        all files in a directory\">\r\n    <property name=\"DatasetScan\" value=\"true\"
+        />\r\n    <metadata inherited=\"true\">\r\n      <serviceName>all</serviceName>\r\n
+        \   </metadata>\r\n  </catalogRef>\r\n  <catalogRef xlink:href=\"enhancedCatalog.xml\"
+        xlink:title=\"Test Enhanced Catalog\" name=\"Test Enhanced Catalog\" />\r\n</catalog>\r\n"}
+    headers:
+      Content-Language: [en-US]
+      Content-Type: [application/xml;charset=UTF-8]
+      Date: ['Tue, 10 Jul 2018 17:27:42 GMT']
+      Server: [Apache-Coyote/1.1]
+    status: {code: 200, message: OK}
+version: 1

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -49,7 +49,6 @@ def test_access_default_catalog():
     url = ('http://localhost:8081/thredds/catalog/catalog.xml')
     cat = TDSCatalog(url)
     ds = list(cat.datasets.values())[0]
-    assert 'opendap' in ds.access_urls
     assert 'OPENDAP' in ds.access_urls
 
 

--- a/siphon/tests/test_catalog.py
+++ b/siphon/tests/test_catalog.py
@@ -43,6 +43,16 @@ def test_access():
     assert 'OPENDAP' in ds.access_urls
 
 
+@recorder.use_cassette('thredds-test-default-5-0')
+def test_access_default_catalog():
+    """Test case-insensitive parsing of access methods in default catalog."""
+    url = ('http://localhost:8081/thredds/catalog/catalog.xml')
+    cat = TDSCatalog(url)
+    ds = list(cat.datasets.values())[0]
+    assert 'opendap' in ds.access_urls
+    assert 'OPENDAP' in ds.access_urls
+
+
 @recorder.use_cassette('top_level_20km_rap_catalog')
 def test_virtual_access():
     """Test access of virtual datasets."""

--- a/siphon/tests/test_catalog_access.py
+++ b/siphon/tests/test_catalog_access.py
@@ -141,3 +141,40 @@ def test_dataset_no_handler(nids_url):
     with pytest.raises(ValueError) as err:
         cat.datasets[0].access_with_service('UDDC')
     assert 'is not an access method supported' in str(err.value)
+
+
+@recorder.use_cassette('cat_only_http')
+def test_case_insensitive_access():
+    """Test case-insensitive parsing of access methods in default catalog."""
+    url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/noaaport/text/'
+           'tropical/atlantic/hdob/catalog.xml')
+    cat = TDSCatalog(url)
+    access_name = list(cat.datasets[0].access_urls.keys())[0]
+    assert access_name == 'HTTPSERVER'  # test __eq__
+    assert not access_name != 'HTTPSERVER'  # test __eq__
+    assert access_name > 'a'  # test __gt__
+    assert access_name >= 'a'  # test __ge__
+    assert access_name < 'Z'  # test __lt__
+    assert access_name <= 'Z'  # test __le__
+
+
+@recorder.use_cassette('cat_only_http')
+def test_manage_access_types_case_insensitive():
+    """Test case-insensitive parsing of access methods in default catalog."""
+    url = ('http://thredds-test.unidata.ucar.edu/thredds/catalog/noaaport/text/'
+           'tropical/atlantic/hdob/catalog.xml')
+    cat = TDSCatalog(url)
+    ds = cat.datasets[0]
+    wrong_case_key = 'HTTPSERVER'
+    test_string = 'test'
+    http_url = ('http://thredds-test.unidata.ucar.edu/thredds/fileServer/noaaport/'
+                'text/tropical/atlantic/hdob/High_density_obs_20170824.txt')
+    assert ds.access_urls == {'HTTPSERVER': http_url}  # test __eq__
+    assert ds.access_urls[wrong_case_key] == http_url  # test __getitem___
+    assert wrong_case_key in ds.access_urls  # test __contains__
+    ds.access_urls[wrong_case_key] = test_string
+    assert ds.access_urls[wrong_case_key] == test_string  # test __setitem__
+    try:
+        del ds.access_urls[wrong_case_key]  # test__delitem
+    except KeyError:
+        pytest.fail('KeyError: ' + wrong_case_key)


### PR DESCRIPTION
Use case-insensitive comparisons for service names to handle catalog xmls which define either "OPenDAP", "OPENDAP", or "opendap", for example.