### PR TITLE
More Maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # After changing this file, check it on:
 #   http://lint.travis-ci.org/
 language: python
-sudo: falsei
+sudo: false
 dist: xenial
 
 addons:
@@ -37,14 +37,13 @@ env:
 
 matrix:
   include:
-    - python: "3.6-dev"
-      env: PRE="--pre"
     - python: "3.7-dev"
       env: PRE="--pre"
+    - python: "3.7-dev"
+      env: TASK="docs" PRE="--pre"
     - python: nightly
       env: PRE="--pre"
   allow_failures:
-    - python: "3.6-dev"
     - python: "3.7-dev"
     - python: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,9 @@ before_install:
       pkg-config --modversion proj;
     else
       export TEST_OPTS="--flake8";
+      if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then
+        export EXTRA_PACKAGES="$EXTRA_PACKAGES flake8-bugbear";
+      fi;
       if [[ $TASK == "coverage" ]]; then
         export TEST_OPTS="$TEST_OPTS --cov=siphon";
         pip install pytest-cov;

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - flake8-pep3101
   - flake8-print
   - flake8-quotes
+  - flake8-rst-docstrings
   - pep8-naming
   - matplotlib
   - xarray >=0.10.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ application-import-names = siphon
 import-order-style = google
 inline-quotes = single
 multiline-quotes = double
+rst-roles = class, data, func, meth, mod
 
 [tool:pytest]
 norecursedirs = build docs

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
                  'flake8>3.2.0', 'flake8-builtins', 'flake8-comprehensions',
                  'flake8-copyright', 'flake8-docstrings', 'flake8-import-order',
                  'flake8-mutable', 'flake8-pep3101', 'flake8-print', 'flake8-quotes',
-                 'pep8-naming',
+                 'flake8-rst-docstrings', 'pep8-naming',
                  'vcrpy~=1.5,!=1.7.0,!=1.7.1,!=1.7.2,!=1.7.3', 'xarray>=0.10.2'],
         'doc': ['sphinx>=1.3,!=1.6.4', 'sphinx-gallery', 'doc8', 'm2r'],
         # SciPy needed for cartopy; we don't use cartopy[plotting] because

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
                  'Operating System :: OS Independent',
                  'License :: OSI Approved :: BSD License'],
 
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
     install_requires=dependencies,
     extras_require={
         'netcdf': 'netCDF4>=1.1.0',

--- a/siphon/cdmr/tests/test_dataset.py
+++ b/siphon/cdmr/tests/test_dataset.py
@@ -112,7 +112,7 @@ def test_tds5_attr():
     """Test handling TDS 5's new attributes."""
     ds = Dataset('http://localhost:8080/thredds/cdmremote/nc4/vlen/tst_vl.nc4')
     var = ds.variables['var']
-    assert getattr(var, '_ChunkSizes') == 3
+    assert var._ChunkSizes == 3
 
 
 @recorder.use_cassette('tds5_vlen')

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -37,7 +37,7 @@ class IGRAUpperAir(HTTPEndPoint):
         """Retreive IGRA version 2 data for one station.
 
         Parameters
-        --------
+        ----------
         site_id : str
             11-character IGRA2 station identifier.
 
@@ -127,7 +127,7 @@ class IGRAUpperAir(HTTPEndPoint):
         """Identify lines containing headers within the range begin_date to end_date.
 
         Parameters
-        -----
+        ----------
         lines: list
             list of lines from the IGRA2 data file.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
A variety of little things:
* Add `python_requires` to `setup.py`, which will be good as the next release is the last for 2.7
* Update Travis config to no longer build Python 3.6-dev, but instead add doc build on 3.7-dev
* Enable a couple more flake8 plugins

This should fail initially with the new plugins, at which point I'll add a commit fixing the failures.