### PR TITLE
MNT: Update flake8-docstrings config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ import-order-style = google
 inline-quotes = single
 multiline-quotes = double
 rst-roles = class, data, func, meth, mod
+docstring-convention = numpy
 
 [tool:pytest]
 norecursedirs = build docs

--- a/siphon/simplewebservice/acis.py
+++ b/siphon/simplewebservice/acis.py
@@ -64,6 +64,6 @@ def acis_request(method, params):
 
 
 class AcisApiException(Exception):
-    """This class handles exceptions raised by the acis_request function."""
+    """Handle exceptions raised by the acis_request function."""
 
     pass

--- a/siphon/simplewebservice/igra2.py
+++ b/siphon/simplewebservice/igra2.py
@@ -75,7 +75,7 @@ class IGRAUpperAir(HTTPEndPoint):
     def _get_data(self):
         """Process the IGRA2 text file for observations at site_id matching time.
 
-        Return:
+        Returns
         -------
             :class: `pandas.DataFrame` containing the body data.
             :class: `pandas.DataFrame` containing the header data.


### PR DESCRIPTION
Sets numpy as the docstring convention, which catches a few more things. I'll fix the couple outstanding style issues once I see CI flag them.