### PR TITLE
Include tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include versioneer.py
 include siphon/_version.py
 recursive-include examples *
 recursive-include docs *
+recursive-include siphon/tests *
 prune docs/build
 prune docs/examples
 prune docs/api/generated


### PR DESCRIPTION
In OpenBSD we use the regression tests in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball makes that much easier.