### PR TITLE
Pass keyword arguments to TDSCatalog object

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -265,7 +265,7 @@ class TDSCatalog(object):
 
     """
 
-    def __init__(self, catalog_url):
+    def __init__(self, catalog_url, **kwargs):
         """
         Initialize the TDSCatalog object.
 
@@ -276,9 +276,10 @@ class TDSCatalog(object):
 
         """
         self.session = session_manager.create_session()
+        session_manager.set_session_options(**kwargs)
 
         # get catalog.xml file
-        resp = self.session.get(catalog_url)
+        resp = self.session.get(catalog_url, **kwargs)
         resp.raise_for_status()
 
         # top level server url


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
My corporate network does not allow for standard SSL connections to weather forecast servers.  I found that by allowing for passing keywords into the TDSCatalog object and then further into the session manager, I could send the appropriate headers and option flags into urllib that allow the get request to succeed.  
#### Checklist
<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
- [ ] Closes #281 
- [ ] Tests added
- [ ] Fully documented
