### PR TITLE
Add mode option for remote_open()

### DIFF
--- a/siphon/catalog.py
+++ b/siphon/catalog.py
@@ -610,18 +610,36 @@ class Dataset(object):
             with open(filename, 'wb') as outfile:
                 outfile.write(infile.read())
 
-    def remote_open(self):
+    def remote_open(self, mode='b', encoding='ascii', errors='ignore'):
         """Open the remote dataset for random access.
 
         Get a file-like object for reading from the remote dataset, providing random access,
         similar to a local file.
+
+        Parameters
+        ----------
+        mode : 'b' or 't', optional
+            Mode with which to open the remote data; 'b' for binary, 't' for text. Defaults
+            to 'b'.
+
+        encoding : str, optional
+            If ``mode`` is text, the encoding to use to decode the binary data into text.
+            Defaults to 'ascii'.
+
+        errors : str, optional
+            If ``mode`` is text, the error handling behavior to pass to `bytes.decode`.
+            Defaults to 'ignore'.
 
         Returns
         -------
         A random access, file-like object
 
         """
-        return self.access_with_service('HTTPServer')
+        fobj = self.access_with_service('HTTPServer')
+        if mode == 't':
+            from io import StringIO
+            fobj = StringIO(fobj.read().decode(encoding, errors))
+        return fobj
 
     def remote_access(self, service=None, use_xarray=None):
         """Access the remote dataset.
@@ -714,7 +732,7 @@ class Dataset(object):
                     import xarray as xr
                     provider = xr.open_dataset
                 except ImportError:
-                    raise ImportError('xarray to be installed if `use_xarray` is True.')
+                    raise ImportError('xarray needs to be installed if `use_xarray` is True.')
             else:
                 try:
                     from netCDF4 import Dataset as NC4Dataset

--- a/siphon/tests/fixtures/fronts_cat_open
+++ b/siphon/tests/fixtures/fronts_cat_open
@@ -1,0 +1,2259 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Siphon (0.8.0+92.gde5851d.dirty)
+    method: GET
+    uri: https://thredds-test.unidata.ucar.edu/thredds/catalog/noaaport/text/fronts/catalog.xml
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<catalog xmlns=\"http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.2\">\r\n  <service
+        name=\"latest\" serviceType=\"Resolver\" base=\"\" />\r\n  <service name=\"fullServices\"
+        serviceType=\"Compound\" base=\"\">\r\n    <service name=\"ncdods\" serviceType=\"OPENDAP\"
+        base=\"/thredds/dodsC/\" />\r\n    <service name=\"HTTPServer\" serviceType=\"HTTPServer\"
+        base=\"/thredds/fileServer/\" />\r\n    <service name=\"wcs\" serviceType=\"WCS\"
+        base=\"/thredds/wcs/\" />\r\n    <service name=\"wms\" serviceType=\"WMS\"
+        base=\"/thredds/wms/\" />\r\n    <service name=\"ncss\" serviceType=\"NetcdfSubset\"
+        base=\"/thredds/ncss/grid\" />\r\n    <service name=\"cdmremote\" serviceType=\"CdmRemote\"
+        base=\"/thredds/cdmremote/\" />\r\n    <service name=\"gridcoverage\" serviceType=\"CdmrFeature\"
+        base=\"/thredds/cdmrfeature/grid/\" />\r\n    <service name=\"ncml\" serviceType=\"NCML\"
+        base=\"/thredds/ncml/\" />\r\n    <service name=\"uddc\" serviceType=\"UDDC\"
+        base=\"/thredds/uddc/\" />\r\n    <service name=\"iso\" serviceType=\"ISO\"
+        base=\"/thredds/iso/\" />\r\n  </service>\r\n  <dataset name=\"fronts/\">\r\n
+        \   <serviceName>HTTPServer</serviceName>\r\n    <property name=\"DatasetScan\"
+        value=\"true\" />\r\n    <metadata inherited=\"true\">\r\n      <serviceName>HTTPServer</serviceName>\r\n
+        \   </metadata>\r\n    <dataset name=\"Fronts_KWBC_20210203_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.95</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T01:40:17.593Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210203_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.031</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T04:49:44.607Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210203_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.536</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T07:39:51.924Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210203_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.055</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T10:42:22.448Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210203_1100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_1100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_1100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.413</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T11:04:52.351Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210203_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.513</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T13:31:53.479Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210203_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.105</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T16:31:33.343Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210203_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.37</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T19:30:32.215Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210203_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210203_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210203_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.057</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T22:29:38.241Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210204_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210204_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210204_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.923</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T01:37:11.271Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210204_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210204_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210204_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.452</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T05:33:17.465Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210204_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210204_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210204_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.106</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T07:33:18.132Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210204_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210204_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210204_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.044</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T10:37:54.818Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210204_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210204_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210204_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.221</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T13:33:24.896Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210204_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210204_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210204_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.002</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T16:31:03.142Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210204_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210204_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210204_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.899</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T19:39:03.926Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210204_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210204_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210204_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.687</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T22:30:16.987Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210205_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210205_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210205_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.313</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T01:30:38.441Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210205_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210205_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210205_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.165</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T04:41:44.115Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210205_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210205_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210205_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.194</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T07:41:45.145Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210205_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210205_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210205_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.035</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T10:20:51.101Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210205_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210205_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210205_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.146</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T13:35:49.911Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210205_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210205_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210205_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.056</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T16:55:24.084Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210205_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210205_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210205_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.184</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T19:39:28.811Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210205_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210205_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210205_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.229</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T22:41:33.378Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210206_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210206_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210206_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.604</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T01:30:17.169Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210206_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210206_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210206_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.459</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T04:31:40.762Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210206_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210206_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210206_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.451</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T07:38:15.276Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210206_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210206_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210206_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.411</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T10:27:53.148Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210206_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210206_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210206_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.439</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T13:32:26.056Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210206_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210206_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210206_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.403</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T16:38:30.040Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210206_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210206_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210206_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.304</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T19:42:04.196Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210206_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210206_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210206_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.361</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T22:59:10.715Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210207_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210207_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210207_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.483</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T01:30:16.044Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210207_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210207_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210207_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.248</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T04:38:15.969Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210207_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210207_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210207_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.211</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T07:48:49.550Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210207_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210207_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210207_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.092</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T10:25:54.584Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210207_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210207_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210207_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.935</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T13:32:23.440Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210207_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210207_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210207_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.237</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T16:33:00.308Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210207_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210207_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210207_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.036</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T19:37:04.360Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210207_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210207_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210207_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.177</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T22:42:37.144Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.364</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T01:25:42.280Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.333</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T04:29:49.954Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.322</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T05:17:47.338Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.414</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T07:35:47.792Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.141</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T10:22:55.956Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.95</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T13:30:58.773Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.085</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T16:38:01.425Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.025</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T19:41:37.013Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210208_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210208_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210208_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.059</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T22:41:44.432Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.348</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T01:31:12.894Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.34</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T04:20:50.387Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.212</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T07:22:50.988Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.376</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T10:20:03.807Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.541</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T13:33:58.917Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.472</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T16:45:36.029Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.888</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T17:33:39.234Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.521</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T19:41:09.018Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_2000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_2000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_2000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.521</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T20:25:45.005Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210209_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210209_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210209_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.161</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T22:57:46.783Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.778</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T01:32:17.171Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.76</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T04:32:53.937Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.632</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T07:38:28.635Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.977</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T10:27:36.138Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.328</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T13:39:06.263Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.832</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T16:46:11.270Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.492</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T17:07:25.671Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.878</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T19:56:44.598Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.564</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T22:34:20.006Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210210_2300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210210_2300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210210_2300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.933</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T23:04:20.579Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.66</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T01:30:51.642Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.21</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T04:35:26.345Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.18</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T07:49:28.965Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_0800.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_0800.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_0800.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.18</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T08:10:59.246Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.388</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T10:31:32.894Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.617</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T13:48:32.084Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.983</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T16:45:11.489Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.185</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T17:45:40.591Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.066</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T19:40:28.671Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.928</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T22:42:47.896Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210211_2300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210211_2300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210211_2300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.376</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T23:46:19.168Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">8.118</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T01:45:21.832Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_0300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_0300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_0300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.707</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T03:48:24.235Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.822</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T05:03:57.149Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.346</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T07:48:59.627Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.312</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T10:54:05.083Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.736</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T13:35:35.377Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.951</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T16:39:11.508Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.428</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T17:30:43.958Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.731</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T19:35:14.959Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210212_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210212_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210212_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.526</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T22:43:21.893Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.522</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T01:32:53.741Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_0200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_0200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_0200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.507</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T02:38:53.597Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.392</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T04:47:56.116Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.296</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T07:39:01.691Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.48</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T10:31:38.883Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">7.258</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T13:50:13.505Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.266</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T16:30:42.265Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.396</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T19:29:43.103Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210213_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210213_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210213_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.004</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T22:29:58.061Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.739</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T01:59:58.571Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_0200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_0200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_0200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.373</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T02:11:27.460Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.028</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T04:45:31.788Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.29</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T07:41:33.985Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_0800.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_0800.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_0800.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.13</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T08:56:08.562Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.294</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T10:40:39.081Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.297</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T13:43:11.051Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.010</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T16:31:14.155Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.132</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T19:30:47.189Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210214_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210214_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210214_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.071</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T22:30:27.305Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.401</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T01:30:23.860Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.379</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T04:49:01.961Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.384</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T07:50:01.486Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_0800.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_0800.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_0800.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.291</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T08:49:36.427Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.622</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T10:33:41.160Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.212</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T13:39:45.051Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.033</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T16:50:19.902Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.399</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T17:24:49.816Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.482</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T19:32:18.993Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210215_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210215_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210215_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.263</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T22:53:56.656Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.972</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T01:32:59.103Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.46</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T04:41:32.068Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.455</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T05:02:00.340Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.391</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T07:46:35.107Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_0800.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_0800.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_0800.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.391</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T08:00:34.480Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.346</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T10:44:09.218Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.260</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T13:55:12.946Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.006</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T16:45:47.770Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.486</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T17:22:05.009Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.733</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T19:33:51.574Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210216_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210216_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210216_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.353</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T22:42:54.621Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.746</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T01:34:27.720Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_0200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_0200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_0200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.74</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T02:02:31.404Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.426</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T04:39:32.484Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.751</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T07:39:33.075Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.329</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T10:53:40.981Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_1100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_1100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_1100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.329</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T11:52:36.488Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.591</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T13:35:40.347Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.168</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T16:52:14.267Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">7.564</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T19:36:17.434Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.795</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T22:57:50.796Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210217_2300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210217_2300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210217_2300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.521</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T23:11:50.572Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.634</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T01:50:51.940Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.163</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T04:47:27.697Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.123</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T05:36:00.387Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.276</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T07:48:30.576Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.231</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T10:37:38.284Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.298</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T13:28:38.901Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.164</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T16:35:09.682Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.126</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T17:31:45.269Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.316</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T19:36:17.643Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210218_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210218_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210218_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.262</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T22:49:22.566Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.316</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T01:35:25.640Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.289</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T04:30:02.513Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.646</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T07:36:33.915Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.408</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T10:32:06.635Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.799</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T13:45:40.888Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.019</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T16:37:16.405Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.506</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T17:15:48.475Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.628</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T19:39:20.610Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210219_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210219_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210219_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.735</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T22:44:23.891Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.39</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T01:45:56.557Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.115</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T04:30:07.477Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.888</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T07:28:30.828Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.088</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T10:27:08.940Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.349</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T13:32:34.074Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.913</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T16:35:06.567Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_1700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_1700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_1700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.438</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T17:30:35.382Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.724</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T19:50:39.110Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210220_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210220_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210220_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.522</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T22:44:42.329Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210221_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210221_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210221_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.177</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T01:37:10.012Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210221_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210221_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210221_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.909</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T04:29:55.897Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210221_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210221_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210221_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.756</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T07:30:18.850Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210221_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210221_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210221_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.718</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T10:28:53.246Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210221_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210221_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210221_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.374</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T13:23:54.252Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210221_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210221_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210221_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.158</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T16:52:29.863Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210221_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210221_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210221_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.72</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T19:37:33.450Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210221_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210221_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210221_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.457</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T22:35:38.233Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210222_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210222_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210222_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.096</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T01:35:12.638Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210222_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210222_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210222_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.781</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T04:29:44.397Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210222_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210222_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210222_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.67</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T07:30:42.822Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210222_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210222_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210222_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.701</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T10:29:23.154Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210222_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210222_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210222_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.983</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T13:30:02.269Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210222_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210222_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210222_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.828</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T16:29:27.475Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210222_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210222_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210222_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.106</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T19:30:56.518Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210222_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210222_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210222_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.482</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T22:50:30.275Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210223_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210223_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210223_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.334</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T01:49:00.779Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210223_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210223_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210223_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.224</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T04:30:02.144Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210223_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210223_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210223_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.942</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T07:30:34.358Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210223_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210223_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210223_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.869</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T10:29:36.543Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210223_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210223_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210223_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.528</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T13:30:07.797Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210223_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210223_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210223_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.446</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T16:23:07.816Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210223_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210223_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210223_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.168</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T19:17:09.537Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210223_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210223_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210223_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.37</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T22:14:42.996Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210224_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210224_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210224_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.225</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T01:37:44.795Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210224_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210224_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210224_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.369</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T04:29:52.334Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210224_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210224_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210224_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.426</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T07:29:51.742Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210224_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210224_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210224_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.152</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T10:28:21.217Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210224_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210224_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210224_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.128</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T13:36:55.385Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210224_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210224_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210224_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.525</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T16:17:23.973Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210224_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210224_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210224_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.525</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T19:15:25.653Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210224_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210224_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210224_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.447</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T22:21:28.081Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210225_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210225_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210225_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.188</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T01:30:34.525Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210225_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210225_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210225_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.143</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T04:30:32.350Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210225_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210225_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210225_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.065</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T07:30:37.470Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210225_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210225_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210225_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.985</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T10:28:38.876Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210225_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210225_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210225_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.621</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T13:53:12.070Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210225_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210225_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210225_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.778</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T16:24:41.835Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210225_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210225_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210225_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.019</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T19:30:14.050Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210225_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210225_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210225_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.751</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T22:20:33.195Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.223</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T01:48:07.112Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.692</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T04:41:05.556Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.382</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T05:13:09.035Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_0800.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_0800.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_0800.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.608</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T08:03:09.737Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">7.024</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T10:59:41.455Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_1100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_1100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_1100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.664</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T11:02:43.116Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.637</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T13:46:15.104Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.071</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T16:34:18.686Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.732</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T19:53:21.591Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_2000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_2000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_2000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.088</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T20:44:51.991Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210226_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210226_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210226_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.763</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T22:28:21.562Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.833</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T01:35:25.291Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.016</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T04:31:29.971Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.258</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T05:02:25.676Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.295</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T07:34:58.149Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.196</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T10:47:31.521Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.705</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T13:36:03.242Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.836</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T16:26:33.788Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.45</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T19:26:36.535Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210227_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210227_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210227_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.342</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T22:22:09.238Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.665</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T01:33:40.327Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.603</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T04:31:43.608Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.856</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T05:00:13.452Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.058</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T07:36:13.080Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.059</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T10:58:15.151Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.954</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T13:32:48.087Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.713</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T16:25:48.833Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.573</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T19:27:53.353Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210228_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210228_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210228_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.48</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T22:30:58.795Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.648</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T01:40:59.743Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.801</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T04:50:32.462Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.005</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T07:39:03.163Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_0800.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_0800.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_0800.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.997</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T08:01:33.474Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.357</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T10:55:37.483Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.711</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T13:42:04.948Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.081</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T16:42:08.056Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.242</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T19:35:12.606Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210301_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210301_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210301_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.259</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T22:46:14.314Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.478</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T01:42:15.445Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_0200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_0200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_0200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.489</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T02:55:44.761Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.717</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T04:35:47.832Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.119</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T05:03:47.289Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.865</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T07:50:00.353Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_0800.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_0800.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_0800.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.839</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T08:15:52.594Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.908</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T10:55:54.243Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.438</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T13:46:25.627Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.431</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T16:45:26.332Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.432</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T19:50:30.929Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210302_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210302_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210302_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.269</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T22:51:05.509Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.777</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T01:37:04.843Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_0200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_0200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_0200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.814</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T02:30:18.520Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.268</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T04:31:07.217Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.588</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T05:07:05.193Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.391</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T07:42:12.272Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.829</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T10:50:18.066Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.014</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T13:54:12.860Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.396</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T16:44:43.705Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.558</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T19:58:19.540Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210303_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210303_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210303_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.363</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T22:47:19.838Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210304_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210304_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210304_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">5.03</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T01:42:53.115Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210304_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210304_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210304_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.794</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T04:47:24.207Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210304_0500.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210304_0500.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210304_0500.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.187</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T05:30:24.959Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210304_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210304_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210304_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.258</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T07:38:58Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210304_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210304_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210304_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">8.58</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T10:54:29.635Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210304_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210304_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210304_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">4.41</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T13:41:04.424Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210304_2000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210304_2000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210304_2000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.798</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T20:00:28.703Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210304_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210304_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210304_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.938</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T22:31:42.216Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210305_0100.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210305_0100.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210305_0100.txt\">\r\n      <dataSize
+        units=\"Kbytes\">3.317</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T01:57:11.532Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210305_0400.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210305_0400.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210305_0400.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.633</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T04:29:12.377Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210305_0700.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210305_0700.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210305_0700.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.555</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T07:30:15.367Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210305_1000.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210305_1000.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210305_1000.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.493</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T10:29:16.877Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210305_1300.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210305_1300.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210305_1300.txt\">\r\n      <dataSize
+        units=\"Kbytes\">7.018</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T13:49:50.969Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210305_1600.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210305_1600.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210305_1600.txt\">\r\n      <dataSize
+        units=\"Kbytes\">6.049</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T16:48:51.701Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210305_1900.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210305_1900.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210305_1900.txt\">\r\n      <dataSize
+        units=\"Kbytes\">2.069</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T19:30:54.847Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_KWBC_20210305_2200.txt\" ID=\"noaaport-text/fronts/Fronts_KWBC_20210305_2200.txt\"
+        urlPath=\"noaaport/text/fronts/Fronts_KWBC_20210305_2200.txt\">\r\n      <dataSize
+        units=\"Kbytes\">1.872</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T22:30:14.062Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210203_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210203_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210203_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.283</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T01:40:20.609Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210203_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210203_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210203_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.919</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T04:50:10.763Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210203_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210203_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210203_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.987</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T07:40:07.514Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210203_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210203_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210203_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.232</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T11:05:04.273Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210203_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210203_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210203_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.962</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T13:32:03.541Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210203_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210203_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210203_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.459</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T16:32:05.117Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210203_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210203_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210203_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.772</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T19:31:04.680Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210203_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210203_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210203_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.391</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-03T22:30:20.889Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210204_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210204_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210204_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.242</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T01:37:05.509Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210204_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210204_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210204_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.343</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T05:33:09.577Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210204_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210204_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210204_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.531</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T07:33:12.093Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210204_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210204_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210204_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.456</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T10:38:03.679Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210204_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210204_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210204_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.632</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T13:34:04.575Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210204_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210204_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210204_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.34</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T16:31:05.511Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210204_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210204_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210204_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.251</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T19:39:14.492Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210204_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210204_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210204_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">1.977</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-04T22:30:19.640Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210205_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210205_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210205_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.772</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T01:31:04.754Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210205_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210205_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210205_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.59</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T04:42:06.483Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210205_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210205_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210205_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.622</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T07:42:07.876Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210205_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210205_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210205_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.47</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T10:21:06.696Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210205_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210205_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210205_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.292</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T13:36:05.741Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210205_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210205_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210205_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.15</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T16:56:06.329Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210205_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210205_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210205_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.638</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T19:40:25.193Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210205_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210205_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210205_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.68</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-05T22:42:06.561Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210206_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210206_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210206_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.137</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T01:31:05.977Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210206_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210206_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210206_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.007</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T04:32:04.864Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210206_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210206_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210206_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.952</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T07:38:05.127Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210206_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210206_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210206_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.951</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T10:28:06.220Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210206_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210206_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210206_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.002</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T13:33:04.638Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210206_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210206_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210206_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.913</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T16:39:05.854Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210206_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210206_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210206_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.866</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T19:42:12.120Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210206_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210206_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210206_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.311</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-06T23:00:09.333Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210207_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210207_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210207_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.008</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T01:31:05.684Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210207_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210207_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210207_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.734</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T04:38:06.980Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210207_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210207_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210207_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.561</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T07:49:04.592Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210207_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210207_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210207_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.549</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T10:26:14.435Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210207_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210207_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210207_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.061</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T13:33:06.002Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210207_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210207_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210207_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.685</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T16:33:06.150Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210207_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210207_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210207_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">4.904</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T19:37:10.232Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210207_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210207_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210207_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.654</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-07T22:43:04.992Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210208_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210208_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210208_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.839</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T01:26:05.285Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210208_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210208_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210208_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.721</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T05:18:04.961Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210208_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210208_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210208_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.354</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T07:36:04.606Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210208_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210208_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210208_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.604</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T10:23:06.873Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210208_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210208_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210208_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.361</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T13:31:04.625Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210208_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210208_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210208_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.506</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T16:38:05.344Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210208_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210208_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210208_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.465</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T19:42:04.915Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210208_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210208_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210208_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.502</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-08T22:42:04.516Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210209_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210209_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210209_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.804</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T01:32:06.308Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210209_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210209_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210209_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.806</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T04:21:06.159Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210209_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210209_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210209_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.676</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T07:23:05.117Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210209_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210209_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210209_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.861</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T10:20:18.474Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210209_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210209_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210209_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.099</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T13:34:04.912Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210209_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210209_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210209_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.631</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T17:33:13.493Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210209_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210209_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210209_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.216</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T20:26:04.804Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210209_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210209_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210209_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.273</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-09T22:58:08.209Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210210_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210210_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210210_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.076</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T01:33:05.550Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210210_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210210_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210210_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.273</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T04:33:12.048Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210210_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210210_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210210_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.267</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T07:39:06.732Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210210_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210210_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210210_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.068</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T10:27:14.861Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210210_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210210_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210210_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.838</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T13:39:06.263Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210210_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210210_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210210_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">13.00</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T17:08:03.946Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210210_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210210_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210210_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.552</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T19:57:05.946Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210210_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210210_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210210_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">10.54</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-10T23:04:05.363Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210211_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210211_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210211_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.228</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T01:31:03.880Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210211_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210211_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210211_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.664</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T04:36:06.551Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210211_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210211_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210211_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.318</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T08:11:05.042Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210211_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210211_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210211_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.339</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T10:32:05.137Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210211_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210211_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210211_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">1.935</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T13:49:06.139Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210211_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210211_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210211_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.147</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T17:46:04.830Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210211_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210211_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210211_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.532</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T19:41:07.213Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210211_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210211_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210211_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">11.44</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-11T23:47:02.845Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210212_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210212_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210212_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">13.25</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T03:48:18.271Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210212_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210212_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210212_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.926</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T05:04:05.607Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210212_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210212_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210212_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.83</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T07:49:03.605Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210212_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210212_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210212_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.829</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T10:54:05.276Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210212_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210212_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210212_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.056</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T13:36:03.825Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210212_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210212_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210212_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.270</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T17:31:05.807Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210212_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210212_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210212_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.320</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T19:35:10.222Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210212_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210212_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210212_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.787</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-12T22:44:02.350Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210213_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210213_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210213_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.202</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T02:39:04.011Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210213_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210213_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210213_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.918</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T04:48:04.153Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210213_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210213_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210213_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.823</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T07:39:05.634Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210213_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210213_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210213_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.053</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T10:32:04.845Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210213_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210213_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210213_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.829</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T13:50:13.978Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210213_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210213_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210213_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.75</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T16:31:04.350Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210213_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210213_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210213_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.919</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T19:30:14.828Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210213_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210213_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210213_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.438</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-13T22:30:07.276Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210214_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210214_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210214_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.593</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T02:12:05.330Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210214_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210214_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210214_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.458</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T04:46:03.991Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210214_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210214_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210214_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.762</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T08:56:10.570Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210214_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210214_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210214_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.763</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T10:41:04.679Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210214_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210214_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210214_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.754</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T13:44:05.760Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210214_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210214_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210214_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.42</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T16:31:06.030Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210214_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210214_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210214_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.542</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T19:31:09.222Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210214_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210214_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210214_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.453</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-14T22:30:24.891Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210215_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210215_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210215_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.904</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T01:31:06.661Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210215_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210215_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210215_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.86</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T04:50:06.918Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210215_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210215_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210215_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.904</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T08:49:14.373Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210215_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210215_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210215_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.143</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T10:34:04.460Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210215_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210215_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210215_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.726</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T13:40:17.055Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210215_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210215_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210215_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.408</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T17:25:08.586Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210215_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210215_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210215_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.030</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T19:33:04.742Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210215_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210215_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210215_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.257</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-15T22:54:04.979Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210216_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210216_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210216_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.025</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T01:33:07.213Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210216_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210216_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210216_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.936</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T05:02:04.989Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210216_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210216_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210216_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.802</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T08:00:30.086Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210216_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210216_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210216_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.843</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T10:44:05.544Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210216_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210216_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210216_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.74</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T13:55:05.441Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210216_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210216_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210216_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.552</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T17:22:02.961Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210216_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210216_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210216_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.344</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T19:34:07.287Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210216_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210216_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210216_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.34</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-16T22:43:02.605Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210217_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210217_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210217_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.664</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T02:03:02.048Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210217_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210217_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210217_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.935</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T04:40:09.680Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210217_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210217_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210217_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.304</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T07:40:05.336Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210217_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210217_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210217_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.786</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T10:54:05.378Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210217_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210217_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210217_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">1.872</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T13:36:04.509Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210217_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210217_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210217_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.028</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T16:52:05.749Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210217_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210217_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210217_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">9.199</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T19:36:05.323Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210217_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210217_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210217_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.852</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-17T23:12:04.497Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210218_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210218_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210218_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.234</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T01:51:06.243Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210218_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210218_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210218_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.158</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T05:36:04.337Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210218_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210218_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210218_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.765</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T07:49:06.981Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210218_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210218_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210218_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.68</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T10:38:06.702Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210218_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210218_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210218_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.785</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T13:29:06.689Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210218_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210218_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210218_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">9.118</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T17:32:11.998Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210218_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210218_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210218_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.886</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T19:37:05.919Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210218_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210218_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210218_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.548</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-18T22:49:18.509Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210219_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210219_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210219_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.25</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T01:36:05.993Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210219_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210219_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210219_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.808</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T04:31:04.034Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210219_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210219_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210219_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.706</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T07:37:06.195Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210219_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210219_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210219_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.398</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T10:32:06.634Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210219_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210219_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210219_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.159</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T13:46:04.882Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210219_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210219_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210219_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.545</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T17:16:04.830Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210219_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210219_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210219_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.902</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T19:39:07.509Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210219_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210219_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210219_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.127</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-19T22:44:05.649Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210220_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210220_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210220_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.844</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T01:46:04.656Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210220_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210220_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210220_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.564</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T04:30:24.607Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210220_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210220_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210220_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.238</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T07:29:04.593Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210220_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210220_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210220_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.483</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T10:27:05.156Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210220_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210220_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210220_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">1.553</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T13:33:04.325Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210220_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210220_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210220_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.542</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T17:31:05.357Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210220_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210220_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210220_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.039</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T19:51:05.191Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210220_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210220_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210220_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.412</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-20T22:45:05.217Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210221_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210221_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210221_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.542</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T01:37:06.186Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210221_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210221_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210221_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.278</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T04:30:08.475Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210221_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210221_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210221_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.072</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T07:30:02.705Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210221_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210221_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210221_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.026</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T10:29:06.336Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210221_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210221_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210221_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">1.581</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T13:25:04.175Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210221_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210221_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210221_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.033</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T16:53:04.242Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210221_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210221_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210221_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.176</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T19:38:03.309Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210221_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210221_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210221_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.999</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-21T22:36:04.228Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210222_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210222_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210222_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.037</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T01:35:04.218Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210222_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210222_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210222_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.118</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T04:30:09.174Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210222_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210222_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210222_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">1.984</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T07:31:04.410Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210222_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210222_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210222_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.035</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T10:30:05.190Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210222_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210222_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210222_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.407</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T13:30:08.418Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210222_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210222_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210222_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.236</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T16:29:07.167Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210222_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210222_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210222_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.588</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T19:31:04.885Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210222_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210222_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210222_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.08</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-22T22:51:04.732Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210223_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210223_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210223_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.774</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T01:49:04.947Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210223_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210223_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210223_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.671</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T04:30:04.977Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210223_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210223_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210223_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.355</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T07:31:07.216Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210223_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210223_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210223_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.248</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T10:30:04.859Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210223_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210223_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210223_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.078</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T13:30:03.354Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210223_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210223_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210223_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.952</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T16:23:04.005Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210223_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210223_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210223_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.611</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T19:18:03.975Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210223_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210223_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210223_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.902</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-23T22:15:04.959Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210224_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210224_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210224_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.675</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T01:38:04.654Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210224_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210224_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210224_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.847</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T04:30:05.190Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210224_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210224_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210224_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.939</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T07:30:04.621Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210224_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210224_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210224_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.573</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T10:28:07.423Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210224_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210224_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210224_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.528</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T13:37:07.742Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210224_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210224_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210224_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.061</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T16:18:06.067Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210224_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210224_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210224_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.071</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T19:16:05.801Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210224_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210224_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210224_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.964</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-24T22:22:07.921Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210225_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210225_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210225_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.635</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T01:31:04.382Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210225_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210225_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210225_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.591</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T04:31:05.406Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210225_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210225_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210225_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.443</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T07:31:06.545Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210225_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210225_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210225_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.367</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T10:29:04.830Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210225_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210225_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210225_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.125</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T13:53:09.153Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210225_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210225_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210225_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.386</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T16:25:06.262Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210225_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210225_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210225_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.727</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T19:30:20.105Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210225_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210225_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210225_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.405</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-25T22:21:04.938Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210226_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210226_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210226_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.985</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T01:48:22.297Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210226_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210226_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210226_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">12.55</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T05:13:03.241Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210226_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210226_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210226_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">4.503</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T08:03:10.148Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210226_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210226_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210226_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">13.31</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T11:03:05.325Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210226_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210226_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210226_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.199</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T13:46:02.831Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210226_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210226_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210226_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.62</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T20:45:05.810Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210226_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210226_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210226_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.07</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T19:53:13.508Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210226_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210226_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210226_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.383</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-26T22:29:05.167Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210227_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210227_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210227_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.447</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T01:36:05.201Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210227_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210227_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210227_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.838</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T05:03:03.682Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210227_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210227_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210227_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.443</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T07:35:06.599Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210227_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210227_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210227_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.71</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T10:48:03.586Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210227_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210227_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210227_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.049</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T13:36:07.262Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210227_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210227_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210227_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.43</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T16:27:05.062Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210227_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210227_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210227_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.941</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T19:27:06.441Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210227_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210227_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210227_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.842</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-27T22:23:04.483Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210228_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210228_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210228_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.278</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T01:34:05.583Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210228_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210228_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210228_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.84</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T05:00:11.814Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210228_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210228_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210228_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.256</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T07:36:05.096Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210228_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210228_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210228_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.295</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T10:58:07.728Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210228_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210228_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210228_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.356</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T13:33:06.403Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210228_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210228_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210228_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.283</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T16:26:05.956Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210228_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210228_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210228_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.11</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T19:28:05.769Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210228_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210228_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210228_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.003</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-02-28T22:31:11.232Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210301_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210301_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210301_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.236</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T01:41:09.914Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210301_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210301_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210301_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.199</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T04:51:05.272Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210301_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210301_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210301_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.402</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T08:01:07.537Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210301_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210301_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210301_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.513</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T10:56:06.888Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210301_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210301_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210301_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.054</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T13:43:02.037Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210301_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210301_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210301_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.506</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T16:43:05.653Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210301_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210301_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210301_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.743</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T19:35:07.875Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210301_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210301_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210301_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.701</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-01T22:47:06.822Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210302_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210302_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210302_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.965</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T02:56:07.466Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210302_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210302_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210302_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.139</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T05:04:10.099Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210302_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210302_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210302_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.972</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T08:17:04.552Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210302_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210302_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210302_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.209</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T10:56:04.324Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210302_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210302_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210302_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.928</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T13:47:06.828Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210302_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210302_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210302_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.942</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T16:46:04.541Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210302_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210302_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210302_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.912</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T19:51:07.337Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210302_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210302_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210302_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.738</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-02T22:52:03.847Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210303_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210303_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210303_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.848</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T02:30:18.412Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210303_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210303_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210303_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.513</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T05:07:05.461Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210303_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210303_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210303_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">4.173</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T07:42:05.430Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210303_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210303_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210303_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.415</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T10:51:05.060Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210303_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210303_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210303_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.398</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T13:54:05.921Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210303_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210303_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210303_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.893</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T16:45:04.072Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210303_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210303_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210303_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.561</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T19:59:07.947Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210303_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210303_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210303_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.857</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-03T22:47:09.671Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210304_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210304_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210304_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">6.168</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T01:43:06.034Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210304_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210304_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210304_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.348</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T05:30:12.548Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210304_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210304_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210304_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.7</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T07:39:09.609Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210304_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210304_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210304_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">10.55</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T10:55:04.194Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210304_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210304_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210304_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">5.355</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T13:41:06.482Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210304_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210304_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210304_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.151</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T20:01:17.150Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210304_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210304_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210304_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.343</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-04T22:31:30.296Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210305_0000.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210305_0000.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210305_0000.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.984</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T01:58:04.346Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210305_0300.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210305_0300.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210305_0300.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.137</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T04:29:14.570Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210305_0600.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210305_0600.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210305_0600.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.081</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T07:30:08.894Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210305_0900.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210305_0900.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210305_0900.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">3.04</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T10:30:13.334Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210305_1200.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210305_1200.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210305_1200.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">8.344</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T13:50:18.721Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210305_1500.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210305_1500.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210305_1500.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">7.238</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T16:50:25.143Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210305_1800.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210305_1800.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210305_1800.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.45</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T19:31:04.826Z</date>\r\n
+        \   </dataset>\r\n    <dataset name=\"Fronts_highres_KWBC_20210305_2100.txt\"
+        ID=\"noaaport-text/fronts/Fronts_highres_KWBC_20210305_2100.txt\" urlPath=\"noaaport/text/fronts/Fronts_highres_KWBC_20210305_2100.txt\">\r\n
+        \     <dataSize units=\"Kbytes\">2.222</dataSize>\r\n      <property name=\"NotAThreddsDataset\"
+        value=\"true\" />\r\n      <date type=\"modified\">2021-03-05T22:30:23.081Z</date>\r\n
+        \   </dataset>\r\n  </dataset>\r\n</catalog>\r\n"
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - Keep-Alive
+      Content-Language:
+      - en-US
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      Content-Type:
+      - application/xml;charset=UTF-8
+      Date:
+      - Fri, 05 Mar 2021 22:54:52 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains;
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: '200'
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Siphon (0.8.0+92.gde5851d.dirty)
+    method: GET
+    uri: https://thredds-test.unidata.ucar.edu/thredds/fileServer/noaaport/text/fronts/Fronts_KWBC_20210203_0100.txt
+  response:
+    body:
+      string: "\x01\r\r\n109 \r\r\nASUS01 KWBC 030140\r\r\nCODSUS\r\r\n \r\r\nCODED
+        SURFACE FRONTAL POSITIONS\r\r\nNWS WEATHER PREDICTION CENTER COLLEGE PARK
+        MD\r\r\n839 PM EST TUE FEB 02 2021\r\r\n \r\r\nVALID 020300Z\r\r\nHIGHS 1027
+        4691 1025 3591 1026 39107 1030 6975 1035 66103 1030 5481 1045 7344 \r\r\nLOWS
+        1010 45116 1005 48111 1014 43102 1004 51116 1012 34101 1006 53105 1021 \r\r\n76102
+        987 4368 990 3971 990 5329 991 5933 1020 7773 1003 51131 1002 49129 \r\r\n1000
+        56155 999 60165 1016 30129 \r\r\nCOLD WK 31128 30128 28129 27130 \r\r\nTROF
+        31108 30108 30106 29106 27105 26105 25104 23104 21103 19103 \r\r\n18101 18101
+        \r\r\nCOLD WK 1679 1481 1482 \r\r\nTROF 21101 20100 1998 1898 \r\r\nWARM WK
+        49129 49127 48125 46124 46123 \r\r\nCOLD WK 45117 43117 41118 37119 35120
+        33122 \r\r\nSTNRY WK 48111 47112 46114 45116 45117 \r\r\nTROF 3479 3282 3286
+        3289 \r\r\nTROF 4179 4182 4386 4789 4990 \r\r\nTROF 43102 45104 47108 48111
+        \r\r\nWARM WK 51116 51115 50115 \r\r\nTROF 34101 33102 32103 \r\r\nTROF 43102
+        41101 38101 34101 \r\r\nSTNRY WK 5588 5596 54101 53105 \r\r\nCOLD WK 53105
+        51107 50108 50110 50111 50114 50115 \r\r\nSTNRY WK 51116 51119 52124 53128
+        55132 \r\r\nTROF 66132 63131 60131 59133 \r\r\nTROF 58106 61111 65115 \r\r\nTROF
+        5796 5992 6087 \r\r\nTROF 5474 5074 4572 \r\r\nTROF 76102 74104 69106 67108
+        \r\r\nCOLD WK 3969 3667 3468 3369 \r\r\nTROF 3971 4170 4368 \r\r\nWARM WK
+        4464 4461 4359 4257 4255 \r\r\nOCFNT WK 4369 4368 4466 4465 4464 \r\r\nCOLD
+        WK 4464 4263 4062 3862 3662 \r\r\nSTNRY WK 6729 6633 6535 6337 5836 5634 5333
+        5231 \r\r\nTROF 6043 6251 6554 6855 7156 7359 7666 7773 \r\r\nOCFNT WK 52132
+        52130 50130 49129 \r\r\nTROF 53133 55136 57141 58149 \r\r\nCOLD WK 49129 48129
+        47129 46131 46133 47136 48138 50141 \r\r\nOCFNT WK 57155 57153 56152 \r\r\nWARM
+        WK 56151 55149 54146 52143 50141 \r\r\nCOLD WK 56152 55152 53153 51154 \r\r\nTROF
+        46127 44127 41128 38130 \r\r\nOCFNT WK 60165 59163 58161 57157 57156 \r\r\nSTNRY
+        WK 60165 59170 59175 59178 \r\r\nTROF 5128 5228 5329 \r\r\nTROF 5932 5930
+        5928 5825 \r\r\nOCFNT WK 31130 31129 31129 31128 \r\r\nWARM WK 31128 31127
+        31126 31125 32124 \r\r\n \r\r\n$$\r\r\n\r\r\n\r\r\n\r\r\n\x03"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '1950'
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Date:
+      - Fri, 05 Mar 2021 22:54:53 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Last-Modified:
+      - Wed, 03 Feb 2021 01:40:17 GMT
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: '200'
+version: 1

--- a/siphon/tests/test_catalog_access.py
+++ b/siphon/tests/test_catalog_access.py
@@ -55,6 +55,15 @@ def test_dataset_remote_open(nids_url):
     assert fobj.read(8) == b'\x01\r\r\n562 '
 
 
+@recorder.use_cassette('fronts_cat_open')
+def test_dataset_remote_open_text():
+    """Test using remote_open to get data as text."""
+    cat = TDSCatalog('https://thredds-test.unidata.ucar.edu/thredds/catalog/noaaport/text'
+                     '/fronts/catalog.xml')
+    fobj = cat.datasets[0].remote_open(mode='t', errors='strict')
+    assert fobj.read(17) == '\x01\r\r\n109 \r\r\nASUS01'
+
+
 @recorder.use_cassette('cat_to_cdmr')
 def test_dataset_remote_access_default(nids_url):
     """Test using the remote_access method to request access using default method."""


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/master/CONTRIBUTING.md
-->

#### Description Of Changes
This allows getting back the results of remote_open() using a StringIO object, rather than BytesIO. This is useful e.g. to pass to MetPy's parsing functions. The call works as:
```python
cat = TDSCatalog(url)
fobj = cat.datasets[0].remote_open(mode='t', errors='replace')
```

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Tests added
- [x] Fully documented