### PR TITLE
Set log level in each module instead of using logging.basicConfig

### DIFF
--- a/src/siphon/catalog.py
+++ b/src/siphon/catalog.py
@@ -22,8 +22,8 @@ except ImportError:
 from .http_util import session_manager
 from .metadata import TDSCatalogMetadata
 
-logging.basicConfig(level=logging.ERROR)
 log = logging.getLogger(__name__)
+log.setLevel(logging.ERROR)
 
 
 class IndexableMapping(OrderedDict):

--- a/src/siphon/cdmr/coveragedataset.py
+++ b/src/siphon/cdmr/coveragedataset.py
@@ -10,8 +10,8 @@ import warnings
 from .cdmremotefeature import CDMRemoteFeature
 from .dataset import AttributeContainer
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
+log.setLevel(logging.WARNING)
 
 
 def reindent_lines(new_leader, source):

--- a/src/siphon/cdmr/dataset.py
+++ b/src/siphon/cdmr/dataset.py
@@ -10,8 +10,8 @@ import logging
 from .cdmremote import CDMRemote
 from .ncstream import unpack_attribute, unpack_variable
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
+log.setLevel(logging.WARNING)
 
 
 class AttributeContainer:

--- a/src/siphon/cdmr/ncstream.py
+++ b/src/siphon/cdmr/ncstream.py
@@ -23,8 +23,8 @@ MAGIC_ERR = b'\xab\xad\xba\xda'
 MAGIC_HEADERCOV = b'\xad\xed\xde\xda'
 MAGIC_DATACOV = b'\xab\xed\xde\xba'
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
+log.setLevel(logging.WARNING)
 
 
 #

--- a/src/siphon/metadata.py
+++ b/src/siphon/metadata.py
@@ -5,8 +5,8 @@
 
 import logging
 
-logging.basicConfig(level=logging.ERROR)
 log = logging.getLogger(__name__)
+log.setLevel(logging.ERROR)
 
 xlink_href_attr = '{http://www.w3.org/1999/xlink}href'
 xlink_title_attr = '{http://www.w3.org/1999/xlink}title'

--- a/src/siphon/ncss_dataset.py
+++ b/src/siphon/ncss_dataset.py
@@ -9,8 +9,8 @@ import re
 
 import numpy as np
 
-logging.basicConfig(level=logging.WARNING)
 log = logging.getLogger(__name__)
+log.setLevel(logging.WARNING)
 
 
 def _without_namespace(tagname):


### PR DESCRIPTION
#### Description Of Changes
This PR sets the logging level using the module-level loggers instead of using `logging.basicConfig(level=)`.

Running `grep -Rn logging.basicConfig --include=*.py` in the root directory of the repo should return nothing now. To check that this solved the issue, try running the following code without the changes, and then with the changes:

```python
import logging
from siphon.catalog import TDSCatalog

logger = logging.getLogger(__name__)
logger.setLevel("INFO")

stream_handler = logging.StreamHandler()

formatter = logging.Formatter(
    fmt="%(asctime)s - $(levelname)s - %(message)s",
    datefmt="%Y-%m-%d %H:%M:%S",
)
stream_handler.setFormatter(formatter)
logger.addHandler(stream_handler)

logger.debug("This is a debug test")
logger.info("This is an info test")
logger.warning("This is a warning test")
logger.error("This is an error test")
logger.critical("This is a critical test")

try:
    print(does_not_exist)
except NameError:
    logger.exception("This is an exception test")
```

Without the changes, two log messages should appear for each logger call greater than debug. One message will be formatted according to the formatter in the code above and the other will be unformatted. With the changes, only the formatted log messages should appear.

#### Checklist

- [x] Closes #317 