### PR TITLE
Bump protobuf to 5.28.2

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.9.1
 numpy==1.26.0
 pandas==2.2.3
-protobuf==4.24.3
+protobuf==5.28.2
 requests==2.28.1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
* Bumps ci version to 5.28.2 (since 5.28.3 isn't available on conda-forge yet)

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

