### PR TITLE
Update dependabot & nightly workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,40 +1,44 @@
 version: 2
 
 updates:
+  # Handle PyPI updates
   - package-ecosystem: pip
     directory: "/ci"
     schedule:
-      interval: daily
-      time: "06:00"
-      timezone: "America/Denver"
-
+      interval: weekly
     allow:
       - dependency-type: all
-
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: "-"
     labels:
       - "Type: Maintenance"
+      - "Area: Infrastructure"
     commit-message:
-      prefix: "MNT: "
+      prefix: "CI: "
       include: "scope"
+    groups:
+      flake8:
+        patterns:
+          - "flake8*"
+          - "pycodestyle"
+          - "pyflakes"
 
+  # Update GitHub Actions versions in workflows
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "daily"
-
+      interval: "weekly"
     allow:
       - dependency-type: all
-
     open-pull-requests-limit: 10
     pull-request-branch-name:
       separator: "-"
     labels:
       - "Type: Maintenance"
+      - "Area: Infrastructure"
     commit-message:
-      prefix: "MNT: "
+      prefix: "CI: "
       include: "scope"

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -1,0 +1,24 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request_target:
+
+jobs:
+  #
+  # Automatically review dependabot PRs and set them to automerge (on successful checks)
+  #
+  Automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+    - name: Set auto-merge
+      run: gh pr merge -R ${{ github.repository }} --merge --auto ${{ github.event.pull_request.number }}
+    - name: Review PR
+      run: gh pr review -R ${{ github.repository }} --approve ${{ github.event.pull_request.number }}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -2,8 +2,8 @@ name: Nightly Checks
 
 on:
   schedule:
-  # Runs at 09Z (3am MDT)
-    - cron: "0 9 * * 2"
+  # Runs at 0930Z (3am MDT)
+    - cron: "30 9 * * 2"
 
   # Allow a manual run
   workflow_dispatch:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
* Reduce Dependabot frequency to weekly since we're up to date; this should help with spurious failures, especially when waiting for conda-forge to upload matching packages
* Sync better labling/messages from MetPy for Dependabot PRs
* Add workflow (from MetPy) to auto-merge Dependabot PRs
* Shift "nightly" builds to 9:30Z to try to avoid issues with data not being available at the top of the hour(seen in #838) 


<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [ ] Closes #838