### PR TITLE
CI: Pin urllib3 to v2.2.3

### DIFF
--- a/.github/workflows/tests-pypi.yml
+++ b/.github/workflows/tests-pypi.yml
@@ -65,6 +65,9 @@ jobs:
               dep = dep.split(';')[0]
               if 'siphon' not in dep:
                 out.write(dep.replace('>=', '==') + '\n')
+            # Needed until vcrpy >=6.0.2 comes out with support for urllib3>=2.3
+            if fname == 'requirements.txt':
+              out.write('urllib3==2.2.3\n')
         EOF
 
     - name: Install from PyPI

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -3,3 +3,4 @@ numpy==2.2.0
 pandas==2.2.3
 protobuf==5.28.3
 requests==2.32.3
+urllib3==2.2.3


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Urllib3 2.3.0 is not compatible with the current (6.0.2) version of vcrpy (see kevin1024/vcrpy#888).

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #865 