### PR TITLE
Bump copyright year in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2013-2019, Siphon Contributors.
+Copyright (c) 2013-2024, Siphon Contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
Only bumping to 2024 since nothing copyrightable has been done in 2025 to date.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
