### PR TITLE
Remove urllib3 from requirements.txt

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -3,4 +3,3 @@ numpy==2.2.4
 pandas==2.3.0
 protobuf==5.29.3
 requests==2.32.4
-urllib3==2.5.0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
We don't directly depend on urllib3 and currently everything works fine with the latest. We still need the pin for urllib 2.2.3 with older vcrpy.


<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
