### PR TITLE
Avoid deprecation warning with Numpy 2.5

### DIFF
--- a/src/siphon/cdmr/dataset.py
+++ b/src/siphon/cdmr/dataset.py
@@ -206,7 +206,7 @@ class Variable(AttributeContainer):
             elif arr.dtype.fields and arr.dtype.fields == dt.fields:
                 pass
             else:
-                arr.dtype = dt
+                arr = arr.view(dt)
 
             # Need to handle removing dimensions that have had an index
             # applied -- the protocol returns them with size 1, but numpy


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes

Numpy 2.5 has deprecated setting the dtype attribute of an array. view() is cheap anyways, since it creates a new array object *without* copying the underlying data. 

We don't yet move to Numpy 2.5 for CI since it needs Python >= 3.12. We'll do that after release.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

