### PR TITLE
Fix release action for download-artifacts@v5 behavior

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,10 @@ jobs:
     steps:
     - name: Download packages
       uses: actions/download-artifact@v8
-
-    - name: Consolidate packages for upload
-      run: |
-        mkdir dist
-        cp packages-*/* dist/
+      with:
+        path: dist/
+        pattern: packages-*
+        merge-multiple: 'true'
 
     - name: Publish Package
       uses: pypa/gh-action-pypi-publish@v1.14.0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
In [v5](https://github.com/actions/download-artifact/releases#release-v5.0.0) of the download-artifacts action, they made behavior more consistent with regards to the resulting path when downloading a single artifact. Unfortunately, this breaks our release action when it comes to assembling all built packages into a single directory.

On the plus side, the current version of download-artifacts has the requisite config to allow us to configure the action to extract all artifacts into a single directory, ready for staging.
