### PR TITLE
Fix IGRA release time parsing

### DIFF
--- a/src/siphon/simplewebservice/igra2.py
+++ b/src/siphon/simplewebservice/igra2.py
@@ -6,7 +6,6 @@
 import datetime
 from io import BytesIO, StringIO
 import itertools
-import sys
 import warnings
 from zipfile import ZipFile
 
@@ -215,7 +214,7 @@ class IGRAUpperAir(HTTPEndPoint):
                         minutes = int(time[2:4])
                         time_seconds = hours * 3600 + minutes * 60
                     else:
-                        sys.exit('Unrecognized time format')
+                        raise ValueError(f'Unrecognized time format "{strformat}"')
 
                 return time_seconds
             return _ctime_strformat

--- a/src/siphon/simplewebservice/igra2.py
+++ b/src/siphon/simplewebservice/igra2.py
@@ -201,7 +201,7 @@ class IGRAUpperAir(HTTPEndPoint):
         def _ctime(strformat='MMMSS'):
             """Return a function converting a string from MMMSS or HHMM to seconds."""
             def _ctime_strformat(val):
-                time = val.strip().zfill(5)
+                time = val.strip().zfill(5 if strformat == 'MMMSS' else 4)
 
                 if int(time) < 0 or int(time) == 9999:
                     return np.nan

--- a/src/siphon/simplewebservice/igra2.py
+++ b/src/siphon/simplewebservice/igra2.py
@@ -200,7 +200,7 @@ class IGRAUpperAir(HTTPEndPoint):
         def _ctime(strformat='MMMSS'):
             """Return a function converting a string from MMMSS or HHMM to seconds."""
             def _ctime_strformat(val):
-                time = val.strip().zfill(5 if strformat == 'MMMSS' else 4)
+                time = val.strip().zfill(len(strformat))
 
                 if int(time) < 0 or int(time) == 9999:
                     return np.nan

--- a/tests/test_igra2.py
+++ b/tests/test_igra2.py
@@ -56,6 +56,13 @@ def subset_date(dt):
     return subsetter
 
 
+def test_release_time_converter_uses_hhmm_width():
+    """Test that release times preserve both hour digits when converted."""
+    converter = IGRAUpperAir()._get_fwf_params()['header']['converters']['release_time']
+
+    assert converter('1142') == 11 * 3600 + 42 * 60
+
+
 @recorder.use_cassette('igra2_sounding',
                        before_record_response=subset_date(datetime(2010, 6, 1)))
 def test_igra2():


### PR DESCRIPTION
#### Description Of Changes

Closes #982. IGRA release times in `HHMM` format now use their four-character field width, preserving both hour digits. The regression covers `1142` converting to 11:42 rather than 01:14.

#### Checklist

- [x] Closes #982
- [x] Tests added
