### PR TITLE
Patch out netCDF4.Dataset in test

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -5,6 +5,7 @@
 
 from datetime import datetime
 import logging
+from unittest.mock import patch
 
 import pytest
 
@@ -416,4 +417,8 @@ def test_oceandata_hyrax_dataset():
     dap_url = cat.datasets[0].access_urls['opendap']
     assert dap_url == ('https://oceandata.sci.gsfc.nasa.gov/opendap/hyrax/SeaWiFS/L3SMI/2000/'
                        '0101/SEASTAR_SEAWIFS_GAC.20000101.L3m.DAY.CHL.chlor_a.9km.nc')
-    assert cat.datasets[0].remote_access()
+
+    # Traffic through netCDF4 isn't captured/stubbed by vcrpy
+    with patch('netCDF4.Dataset') as mocked_dataset:
+        assert cat.datasets[0].remote_access() is not None
+        mocked_dataset.assert_called_once_with(dap_url)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/Unidata/siphon/blob/main/CONTRIBUTING.md
-->

#### Description Of Changes
netCDF4-python OPeNDAP support isn't captured by vcrpy, so this test was accessing the server on every run. This is failing a bunch lately, so patch out the call to Dataset() and just validate that it's used properly--we don't need to check OPeNDAP traffic end-to-end.

This should greatly help more PRs run cleanly, plus eliminates needless server traffic.

<!--
Feel free to remove check-list items aren't relevant to your change

Please use keywords (e.g., Fixes, Closes) to create link to the issues or pull
requests you resolved, so that they will automatically be closed when your pull
request is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### Checklist

- [x] Closes #1076